### PR TITLE
Adding in ability to specify line interpolation methods

### DIFF
--- a/lib/views/LineGraph.js
+++ b/lib/views/LineGraph.js
@@ -12,13 +12,14 @@ class LineGraph extends Graph {
         // (since they're all in the guide layer)
         this.guideClassName = 'y_guide-' + this.id;
         this.guideColor = options.guideColor || this.color;
+        this.interpolate = options.interpolate || 'linear';
     }
 
     draw() {
         var lineFunction = d3.svg.line()
             .x(d => this.xRange(d.x_value))
             .y(d => this.yRange(d.y_value))
-            .interpolate('linear');
+            .interpolate(this.interpolate);
 
         var line = this.d3Svg.selectAll('path.line')
                     .data([this.dataSeries.data]);


### PR DESCRIPTION
This allows users to specify an interpolation method as used by D3. This can be passed as either a string, or as a function.
