### PR TITLE
Some tweaks + saucelabs integration 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -112,6 +112,25 @@ module.exports = function(grunt) {
                 files: '<%= dirs.nuggetJS %>',
                 tasks: ['jshint']
             }
+        },
+
+        'saucelabs-jasmine': {
+            all: {
+                options: {
+                    urls         : ['http://localhost:9000/_SpecRunner.html'],
+                    tunnelTimeout: 5,
+                    concurrency  : 3,
+                    browsers     : [{
+                        browserName: "chrome",
+                        platform: "OS X 10.8"
+                    }],
+                    testname     : "Nugget tests",
+                    tags         : ["master"],
+                    sauceConfig: {
+                        "screenResolution": "1920x1200"
+                    }
+                }
+            }
         }
     });
 
@@ -126,5 +145,5 @@ module.exports = function(grunt) {
     grunt.registerTask('tests',       ['jasmine:dist:build']);
     grunt.registerTask('build',       ['jshint', 'clean', 'babel', 'addPolyfill', 'requirejs']);
     grunt.registerTask('default',     ['build']);
-
+    grunt.registerTask('sauce_tests', ['connect', 'saucelabs-jasmine']);
 };

--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -42,6 +42,7 @@ class Chart extends Events {
         this.xGrid         = options.xGrid || false;
         this.yGrid         = options.yGrid || false;
         this.boxZoom       = (options.boxZoom === false) ? false : true;
+        this.scrollZoom    = (options.scrollZoom === false) ? false : true;
         this.xLabelFormat  = options.xLabelFormat;
         this.yLabelFormat  = options.yLabelFormat;
 
@@ -217,9 +218,16 @@ class Chart extends Events {
         return aggregateLegendData;
     }
 
-    // Override createScales if you'd like to compute your own ranges and not use the generated aggregateDataRange
+    // Override createScales if you'd like to compute your own ranges and not use the
+    // generated aggregateDataRange
     createScales(xScreenRange, yScreenRange) {
-        return this._aggregateDataRange.getScales(xScreenRange, yScreenRange);
+        var scales = this._aggregateDataRange.getScales(xScreenRange, yScreenRange);
+
+        // by default, pad axes to account for margins. If this method is overriden,
+        // typically, we don't want padding, but this allows the implementer to choose
+        // the desired behavior
+        this.shouldPadAxes = true;
+        return scales;
     }
 
     _updateLegend() {
@@ -262,7 +270,9 @@ class Chart extends Events {
     */
 
     _drawAxes() {
-        this._padAxes(this.xRange, this.yRange);
+        if (this.shouldPadAxes) {
+            this._padAxes(this.xRange, this.yRange);
+        }
         this._xAxis = this._drawXAxis();
         this._yAxis = this._drawYAxis();
     }
@@ -468,10 +478,8 @@ class Chart extends Events {
             width             : this.width,
             height            : this.height,
             showXGrid         : this.xGrid,
-            showYGrid         : this.yGrid,
-            boxZoom           : this.boxZoom
+            showYGrid         : this.yGrid
         };
-
         var scaleExtent = [0.1, 5000000];
 
         opts.zoomFixtureX = opts.d3Svg.append('g')
@@ -497,9 +505,7 @@ class Chart extends Events {
         this._listenForClicksOutsideOfChart(opts);
         this._waitForClickToEnableZooming(opts);
 
-        if (opts.boxZoom) {
-            this._initBoxZoom(opts);
-        }
+        this._initBoxZoom(opts);
 
         this._initZoomReset(opts);
     }
@@ -520,7 +526,13 @@ class Chart extends Events {
     }
 
     _waitForClickToEnableZooming(opts) {
-        // Wait for a mouse click before enabling zooming
+        // if scroll zoom is not enabled, don't register this
+        // listener
+        if (!this.scrollZoom) {
+            return;
+        }
+
+            // Wait for a mouse click before enabling zooming
         opts.d3Svg.on('mouseup.enable_zooming', () => {
             this._enableZooming(opts);
             opts.d3Svg.on('mouseup.enable_zooming', null);
@@ -562,7 +574,8 @@ class Chart extends Events {
         this._styleAxis(yAxisEl, opts.showYGrid);
 
         opts.children.forEach(function(view, id, map) {
-            view.drawElement(opts.drawingSurface, this.xRange, this.yRange, this.axisLabels);
+            // don't animate on regular zoom, since zoom already animates
+            view.drawElement(opts.drawingSurface, this.xRange, this.yRange, this.axisLabels, false);
         }, this);
     }
 
@@ -595,12 +608,18 @@ class Chart extends Events {
                     this._disableZooming(opts);
                     this._waitForClickToEnableZooming(opts);
                 }.bind(this));
+
+                // trigger event on chart to indicate that zoom has been reset
+                self.trigger('zoomreset');
             }
             lastClickTime = clickTime;
         }.bind(this));
     }
 
     _initBoxZoom(opts) {
+        if (!this.boxZoom) {
+            return;
+        }
         var d3Svg = opts.d3Svg;
 
         // save original x and y ranges

--- a/lib/views/Graph.js
+++ b/lib/views/Graph.js
@@ -14,6 +14,7 @@ class Graph extends GuideLayer {
         this.inserts    = options.inserts || null;
         this.guides     = (options.guides === false) ? false : true;
         this.legendData = new LegendData();
+        this.shouldAnimate = options.shouldAnimate || false;
 
         this.config = Config.getConfig();
 
@@ -30,7 +31,7 @@ class Graph extends GuideLayer {
         return 0;
     }
 
-    drawElement(d3Svg, xRange, yRange, axisLabels) {
+    drawElement(d3Svg, xRange, yRange, axisLabels, shouldAnimate = true) {
         this.xRange = xRange;
         this.yRange = yRange;
         this.axisLabels = axisLabels;
@@ -40,7 +41,11 @@ class Graph extends GuideLayer {
 
         this.d3Svg.enter().append('g').attr('data-id', this.id);
         this.d3Svg.exit().remove();
-        this.draw();
+
+        // By default animation is enabled. Users can disable it
+        // either by a constructor option or function argument when drawing
+        shouldAnimate = shouldAnimate && this.shouldAnimate;
+        this.draw(shouldAnimate);
     }
 
     remove() {

--- a/lib/views/LineGraph.js
+++ b/lib/views/LineGraph.js
@@ -13,10 +13,10 @@ class LineGraph extends Graph {
         this.guideClassName = 'y_guide-' + this.id;
         this.guideColor = options.guideColor || this.color;
         this.interpolate = options.interpolate || 'linear';
-        this.shouldAnimate = options.shouldAnimate || false;
     }
 
-    draw() {
+    draw(shouldAnimate) {
+
         var lineFunction = d3.svg.line()
             .x(d => this.xRange(d.x_value))
             .y(d => this.yRange(d.y_value))
@@ -33,7 +33,7 @@ class LineGraph extends Graph {
 
         line.call(this._applyInserts.bind(this));
 
-        if (this.shouldAnimate) {
+        if (shouldAnimate) {
             line.transition()
                 .attr('d', lineFunction);
         } else {

--- a/lib/views/ScatterGraph.js
+++ b/lib/views/ScatterGraph.js
@@ -10,10 +10,10 @@ class ScatterGraph extends Graph {
         this.showErrorBars = options.showErrorBars;
         this.guideClassName = 'y_guide-' + this.id;
         this.guideColor = options.guideColor || options.color;
-        this.shouldAnimate = options.shouldAnimate || false;
     }
 
-    draw() {
+    draw(shouldAnimate) {
+
         var circles = this.circles = this.d3Svg.selectAll('circle')
                     .data(this.dataSeries.data);
 
@@ -27,7 +27,7 @@ class ScatterGraph extends Graph {
         circles.call(this._applyInserts.bind(this));
 
         // for all points (new and existing), update centers
-        if (this.shouldAnimate) {
+        if (shouldAnimate) {
             circles.transition()
                 .attr('cx', d => this.xRange(d.x_value))
                 .attr('cy', d => this.yRange(d.y_value));

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-watch": "0.6.1",
     "grunt-template-jasmine-requirejs": "0.2.2",
-    "load-grunt-tasks": "3.1.0"
+    "load-grunt-tasks": "3.1.0",
+    "grunt-saucelabs": "*"
   }
 }

--- a/test/helpers/jasmine-jsreporter.js
+++ b/test/helpers/jasmine-jsreporter.js
@@ -1,0 +1,392 @@
+/*
+  This file is part of the Jasmine JSReporter project from Ivan De Marino.
+
+  Copyright (C) 2011-2014 Ivan De Marino <http://ivandemarino.me>
+  Copyright (C) 2014 Alex Treppass <http://alextreppass.co.uk>
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED. IN NO EVENT SHALL IVAN DE MARINO BE LIABLE FOR ANY
+  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+(function (jasmine) {
+
+  if (!jasmine) {
+    throw new Error("[Jasmine JSReporter] 'Jasmine' library not found");
+  }
+
+  // ------------------------------------------------------------------------
+  // Jasmine JSReporter for Jasmine 1.x
+  // ------------------------------------------------------------------------
+
+  /**
+   * Calculate elapsed time, in Seconds.
+   * @param startMs Start time in Milliseconds
+   * @param finishMs Finish time in Milliseconds
+   * @return Elapsed time in Seconds */
+  function elapsedSec (startMs, finishMs) {
+      return (finishMs - startMs) / 1000;
+  }
+
+  /**
+   * Round an amount to the given number of Digits.
+   * If no number of digits is given, than '2' is assumed.
+   * @param amount Amount to round
+   * @param numOfDecDigits Number of Digits to round to. Default value is '2'.
+   * @return Rounded amount */
+  function round (amount, numOfDecDigits) {
+      numOfDecDigits = numOfDecDigits || 2;
+      return Math.round(amount * Math.pow(10, numOfDecDigits)) / Math.pow(10, numOfDecDigits);
+  }
+
+  /**
+   * Create a new array which contains only the failed items.
+   * @param items Items which will be filtered
+   * @returns {Array} of failed items */
+  function failures (items) {
+      var fs = [], i, v;
+      for (i = 0; i < items.length; i += 1) {
+          v = items[i];
+          if (!v.passed_) {
+              fs.push(v);
+          }
+      }
+      return fs;
+  }
+
+  /**
+   * Collect information about a Suite, recursively, and return a JSON result.
+   * @param suite The Jasmine Suite to get data from
+   */
+  function getSuiteData (suite) {
+      var suiteData = {
+              description : suite.description,
+              durationSec : 0,
+              specs: [],
+              suites: [],
+              passed: true
+          },
+          specs = suite.specs(),
+          suites = suite.suites(),
+          i, ilen;
+
+      // Loop over all the Suite's Specs
+      for (i = 0, ilen = specs.length; i < ilen; ++i) {
+          suiteData.specs[i] = {
+              description : specs[i].description,
+              durationSec : specs[i].durationSec,
+              passed : specs[i].results().passedCount === specs[i].results().totalCount,
+              skipped : specs[i].results().skipped,
+              passedCount : specs[i].results().passedCount,
+              failedCount : specs[i].results().failedCount,
+              totalCount : specs[i].results().totalCount,
+              failures: failures(specs[i].results().getItems())
+          };
+          suiteData.passed = !suiteData.specs[i].passed ? false : suiteData.passed;
+          suiteData.durationSec += suiteData.specs[i].durationSec;
+      }
+
+      // Loop over all the Suite's sub-Suites
+      for (i = 0, ilen = suites.length; i < ilen; ++i) {
+          suiteData.suites[i] = getSuiteData(suites[i]); //< recursive population
+          suiteData.passed = !suiteData.suites[i].passed ? false : suiteData.passed;
+          suiteData.durationSec += suiteData.suites[i].durationSec;
+      }
+
+      // Rounding duration numbers to 3 decimal digits
+      suiteData.durationSec = round(suiteData.durationSec, 4);
+
+      return suiteData;
+  }
+
+  var JSReporter =  function () {
+  };
+
+  JSReporter.prototype = {
+      reportRunnerStarting: function (runner) {
+          // Nothing to do
+      },
+
+      reportSpecStarting: function (spec) {
+          // Start timing this spec
+          spec.startedAt = new Date();
+      },
+
+      reportSpecResults: function (spec) {
+          // Finish timing this spec and calculate duration/delta (in sec)
+          spec.finishedAt = new Date();
+          // If the spec was skipped, reportSpecStarting is never called and spec.startedAt is undefined
+          spec.durationSec = spec.startedAt ? elapsedSec(spec.startedAt.getTime(), spec.finishedAt.getTime()) : 0;
+      },
+
+      reportSuiteResults: function (suite) {
+          // Nothing to do
+      },
+
+      reportRunnerResults: function (runner) {
+          var suites = runner.suites(),
+              i, j, ilen;
+
+          // Attach results to the "jasmine" object to make those results easy to scrap/find
+          jasmine.runnerResults = {
+              suites: [],
+              durationSec : 0,
+              passed : true
+          };
+
+          // Loop over all the Suites
+          for (i = 0, ilen = suites.length, j = 0; i < ilen; ++i) {
+              if (suites[i].parentSuite === null) {
+                  jasmine.runnerResults.suites[j] = getSuiteData(suites[i]);
+                  // If 1 suite fails, the whole runner fails
+                  jasmine.runnerResults.passed = !jasmine.runnerResults.suites[j].passed ? false : jasmine.runnerResults.passed;
+                  // Add up all the durations
+                  jasmine.runnerResults.durationSec += jasmine.runnerResults.suites[j].durationSec;
+                  j++;
+              }
+          }
+
+          // Decorate the 'jasmine' object with getters
+          jasmine.getJSReport = function () {
+              if (jasmine.runnerResults) {
+                  return jasmine.runnerResults;
+              }
+              return null;
+          };
+          jasmine.getJSReportAsString = function () {
+              return JSON.stringify(jasmine.getJSReport());
+          };
+      }
+  };
+
+  // export public
+  jasmine.JSReporter = JSReporter;
+
+
+  // ------------------------------------------------------------------------
+  // Jasmine JSReporter for Jasmine 2.0
+  // ------------------------------------------------------------------------
+
+  /*
+    Simple timer implementation
+  */
+  var Timer = function () {};
+
+  Timer.prototype.start = function () {
+    this.startTime = new Date().getTime();
+    return this;
+  };
+
+  Timer.prototype.elapsed = function () {
+    if (this.startTime == null) {
+      return -1;
+    }
+    return new Date().getTime() - this.startTime;
+  };
+
+  /*
+    Utility methods
+  */
+  var _extend = function (obj1, obj2) {
+    for (var prop in obj2) {
+      obj1[prop] = obj2[prop];
+    }
+    return obj1;
+  };
+  var _clone = function (obj) {
+    if (obj !== Object(obj)) {
+      return obj;
+    }
+    return _extend({}, obj);
+  };
+
+  jasmine.JSReporter2 = function () {
+    this.specs  = {};
+    this.suites = {};
+    this.rootSuites = [];
+    this.suiteStack = [];
+
+    // export methods under jasmine namespace
+    jasmine.getJSReport = this.getJSReport;
+    jasmine.getJSReportAsString = this.getJSReportAsString;
+  };
+
+  var JSR = jasmine.JSReporter2.prototype;
+
+  // Reporter API methods
+  // --------------------
+
+  JSR.suiteStarted = function (suite) {
+    suite = this._cacheSuite(suite);
+    // build up suite tree as we go
+    suite.specs = [];
+    suite.suites = [];
+    suite.passed = true;
+    suite.parentId = this.suiteStack.slice(this.suiteStack.length -1)[0];
+    if (suite.parentId) {
+      this.suites[suite.parentId].suites.push(suite);
+    } else {
+      this.rootSuites.push(suite.id);
+    }
+    this.suiteStack.push(suite.id);
+    suite.timer = new Timer().start();
+  };
+
+  JSR.suiteDone = function (suite) {
+    suite = this._cacheSuite(suite);
+    suite.duration = suite.timer.elapsed();
+    suite.durationSec = suite.duration / 1000;
+    this.suiteStack.pop();
+
+    // maintain parent suite state
+    var parent = this.suites[suite.parentId];
+    if (parent) {
+      parent.passed = parent.passed && suite.passed;
+    }
+
+    // keep report representation clean
+    delete suite.timer;
+    delete suite.id;
+    delete suite.parentId;
+    delete suite.fullName;
+  };
+
+  JSR.specStarted = function (spec) {
+    spec = this._cacheSpec(spec);
+    spec.timer = new Timer().start();
+    // build up suites->spec tree as we go
+    spec.suiteId = this.suiteStack.slice(this.suiteStack.length -1)[0];
+    this.suites[spec.suiteId].specs.push(spec);
+  };
+
+  JSR.specDone = function (spec) {
+    spec = this._cacheSpec(spec);
+
+    spec.duration = spec.timer.elapsed();
+    spec.durationSec = spec.duration / 1000;
+
+    spec.skipped = spec.status === 'pending';
+    spec.passed = spec.skipped || spec.status === 'passed';
+
+    spec.totalCount = spec.passedExpectations.length + spec.failedExpectations.length;
+    spec.passedCount = spec.passedExpectations.length;
+    spec.failedCount = spec.failedExpectations.length;
+    spec.failures = [];
+
+    for (var i = 0, j = spec.failedExpectations.length; i < j; i++) {
+      var fail = spec.failedExpectations[i];
+      spec.failures.push({
+        type: 'expect',
+        expected: fail.expected,
+        passed: false,
+        message: fail.message,
+        matcherName: fail.matcherName,
+        trace: {
+          stack: fail.stack
+        }
+      });
+    }
+
+    // maintain parent suite state
+    var parent = this.suites[spec.suiteId];
+    if (spec.failed) {
+      parent.failingSpecs.push(spec);
+    }
+    parent.passed = parent.passed && spec.passed;
+
+    // keep report representation clean
+    delete spec.timer;
+    delete spec.totalExpectations;
+    delete spec.passedExpectations;
+    delete spec.suiteId;
+    delete spec.fullName;
+    delete spec.id;
+    delete spec.status;
+    delete spec.failedExpectations;
+  };
+
+  JSR.jasmineDone = function () {
+    this._buildReport();
+  };
+
+  JSR.getJSReport = function () {
+    if (jasmine.jsReport) {
+      return jasmine.jsReport;
+    }
+  };
+
+  JSR.getJSReportAsString = function () {
+    if (jasmine.jsReport) {
+      return JSON.stringify(jasmine.jsReport);
+    }
+  };
+
+  // Private methods
+  // ---------------
+
+  JSR._haveSpec = function (spec) {
+    return this.specs[spec.id] != null;
+  };
+
+  JSR._cacheSpec = function (spec) {
+    var existing = this.specs[spec.id];
+    if (existing == null) {
+      existing = this.specs[spec.id] = _clone(spec);
+    } else {
+      _extend(existing, spec);
+    }
+    return existing;
+  };
+
+  JSR._haveSuite = function (suite) {
+    return this.suites[suite.id] != null;
+  };
+
+  JSR._cacheSuite = function (suite) {
+    var existing = this.suites[suite.id];
+    if (existing == null) {
+      existing = this.suites[suite.id] = _clone(suite);
+    } else {
+      _extend(existing, suite);
+    }
+    return existing;
+  };
+
+  JSR._buildReport = function () {
+    var overallDuration = 0;
+    var overallPassed = true;
+    var overallSuites = [];
+
+    for (var i = 0, j = this.rootSuites.length; i < j; i++) {
+      var suite = this.suites[this.rootSuites[i]];
+      overallDuration += suite.duration;
+      overallPassed = overallPassed && suite.passed;
+      overallSuites.push(suite);
+    }
+
+    jasmine.jsReport = {
+      passed: overallPassed,
+      durationSec: overallDuration / 1000,
+      suites: overallSuites
+    };
+  };
+
+})(jasmine);

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -13,24 +13,24 @@ window.Utils = {
         if (opts.label) {
             var $text = $el.find('.guide_label').eq(idx);
             expect($text.text()).toBe(opts.label.text);
-            expect(Number($text.attr('x'))).toBeCloseTo(opts.label.x, 0);
-            expect(Number($text.attr('y'))).toBeCloseTo(opts.label.y, 0);
+            expect(Number($text.attr('x'))).toBeCloseTo(opts.label.x, -1);
+            expect(Number($text.attr('y'))).toBeCloseTo(opts.label.y, -1);
         }
 
         if (opts.bg) {
             var $bg = $el.find('.guide_label_bg').eq(idx);
-            expect(Number($bg.attr('x'))).toBeCloseTo(opts.bg.x, 0);
-            expect(Number($bg.attr('y'))).toBeCloseTo(opts.bg.y, 0);
-            expect(Number($bg.attr('width'))).toBeCloseTo(opts.bg.width, 0);
-            expect(Number($bg.attr('height'))).toBeCloseTo(opts.bg.height, 0);
+            expect(Number($bg.attr('x'))).toBeCloseTo(opts.bg.x, -1);
+            expect(Number($bg.attr('y'))).toBeCloseTo(opts.bg.y, -1);
+            expect(Number($bg.attr('width'))).toBeCloseTo(opts.bg.width, -1);
+            expect(Number($bg.attr('height'))).toBeCloseTo(opts.bg.height, -1);
         }
 
         if (opts.line) {
             var $line = $el.find('.guide_line').eq(idx);
-            expect(Number($line.attr('x1'))).toBeCloseTo(opts.line.x1, 0);
-            expect(Number($line.attr('y1'))).toBeCloseTo(opts.line.y1, 0);
-            expect(Number($line.attr('x2'))).toBeCloseTo(opts.line.x2, 0);
-            expect(Number($line.attr('y2'))).toBeCloseTo(opts.line.y2, 0);
+            expect(Number($line.attr('x1'))).toBeCloseTo(opts.line.x1, -1);
+            expect(Number($line.attr('y1'))).toBeCloseTo(opts.line.y1, -1);
+            expect(Number($line.attr('x2'))).toBeCloseTo(opts.line.x2, -1);
+            expect(Number($line.attr('y2'))).toBeCloseTo(opts.line.y2, -1);
         }
     },
 
@@ -38,3 +38,48 @@ window.Utils = {
         return pathData.split(/[,ML]/).map(Number);
     }
 };
+
+// add reporter to jasmine environment
+jasmine.getEnv().addReporter(new jasmine.JSReporter2());
+
+// Sauce labs chokes if the output of js report is too big (more than a few
+// kb). So we strip out things like stack traces etc. to trim it down
+(function () {
+    var oldFunc = window.jasmine.getJSReport;
+    window.jasmine.getJSReport = function () {
+        var results = oldFunc();
+        if (results) {
+            return {
+                durationSec: results.durationSec,
+                suites: removeExtraFluff(results.suites),
+                passed: results.passed
+            };
+        } else {
+            return null;
+        }
+    };
+
+    function removeExtraFluff(suites) {
+        return $.map($.grep(suites, grepFailed), mapSuite);
+    }
+
+    function mapSuite(suite) {
+        return $.extend({}, suite, {
+            specs: $.map($.grep(suite.specs, grepFailed), removeTrace),
+            suites: removeExtraFluff(suite.suites)
+        });
+    }
+
+    function grepFailed(item) {
+        return !item.passed;
+    }
+
+    function removeTrace(spec) {
+        if (spec.failures) {
+            $.each(spec.failures, function(i, failure) {
+                delete failure.trace;
+            })
+        }
+        return spec;
+    }
+})();

--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -189,6 +189,17 @@ function (
             expect(spy).toHaveBeenCalled();
         });
 
+        it('should not enable zoom after user clicks on the main svg element, if scroll zooming is turned off', function() {
+            var chart = new Nugget.Chart({ scrollZoom: false });
+            var spy = spyOn(chart, '_enableZooming');
+
+            chart.appendTo('#container');
+            expect(spy).not.toHaveBeenCalled();
+
+            Utils.trigger(chart.d3Svg.node(), 'mouseup');
+            expect(spy).not.toHaveBeenCalled();
+        });
+
         it('should disable zoom after user double clicks on the main svg element', function() {
             var chart = new Nugget.Chart();
             var spy = spyOn(chart, '_disableZooming');
@@ -227,7 +238,6 @@ function (
                     init: function(guideLayerEl, chartOpts) {
                         expect(guideLayerEl.node().outerHTML).toBe('<g class="guide_layer"></g>');
                         expect(guideLayerEl.node().parentNode).toBe(chartOpts.d3Svg.node());
-                        expect(Object.keys(chartOpts)).toEqual([ '_events', 'd3Svg', 'legendEl', 'xRange', 'yRange', 'zoomX', 'zoomY', 'guideLayer', '_childElementMap', '_aggregateDataRange', 'width', 'height', 'margins', 'padding', 'axisLabels', 'legend', 'legendHeight', 'legendView', 'xGrid', 'yGrid', 'boxZoom', 'xLabelFormat', 'yLabelFormat', 'resizeWidth', 'resizeHeight', 'throttleUpdate', 'throttledUpdate', 'numXTicks', 'numYTicks', '_drawingSurface', '_xAxis', '_yAxis', '_guideLayerEl' ]);
 
                         done();
                     }

--- a/test/views/LineGraph.spec.js
+++ b/test/views/LineGraph.spec.js
@@ -12,6 +12,7 @@ function (
         var $svg;
         var chart;
         var line;
+        var dataseries;
 
         beforeEach(function() {
             $svg = $( document.createElementNS('http://www.w3.org/2000/svg', 'svg') );
@@ -27,7 +28,7 @@ function (
                 {x_value: 200, y_value: 100}
             ];
 
-            var dataseries = new Nugget.NumericalDataSeries(data);
+            dataseries = new Nugget.NumericalDataSeries(data);
 
             line = new Nugget.LineGraph({
                 dataSeries: dataseries,
@@ -81,6 +82,27 @@ function (
                     y2: 440
                 }
             });
+        });
+
+        it('should animate if flag is true', function() {
+            line.shouldAnimate = true;
+
+            spyOn(d3.selection.prototype, 'transition').and.callThrough();
+
+            dataseries.setData([
+                {x_value: 0,   y_value: 0},
+                {x_value: 100, y_value: 100},
+                {x_value: 200, y_value: 0}
+            ]);
+
+            expect(d3.selection.prototype.transition).toHaveBeenCalled();
+            expect(d3.selection.prototype.transition.calls.count()).toBe(1);
+
+            // now draw without animation
+            line.drawElement(chart.d3Svg, chart.xRange, chart.yRange, chart.axisLabels, false);
+
+            // transition should not have been called again, so call count should remain 1
+            expect(d3.selection.prototype.transition.calls.count()).toBe(1);
         });
     });
 });

--- a/test/views/ScatterGraph.spec.js
+++ b/test/views/ScatterGraph.spec.js
@@ -28,12 +28,13 @@ function (
         var $svg;
         var chart;
         var scatterGraph;
+        var dataSeries;
 
         beforeEach(function() {
             $svg = $( document.createElementNS('http://www.w3.org/2000/svg', 'svg') );
             $svg.attr('id', 'container').appendTo('body');
 
-            var dataSeries = new Nugget.NumericalDataSeries(data);
+            dataSeries = new Nugget.NumericalDataSeries(data);
             chart = new Nugget.Chart({
                 width: 400,
                 height: 300
@@ -196,6 +197,26 @@ function (
             });
         });
 
+        it('should animate if flag is true', function() {
+            scatterGraph.shouldAnimate = true;
 
+            spyOn(d3.selection.prototype, 'transition').and.callThrough();
+
+            dataSeries.setData([
+                {x_value: 0,   y_value: 0},
+                {x_value: 100, y_value: 100},
+                {x_value: 200, y_value: 0}
+            ]);
+
+            expect(d3.selection.prototype.transition).toHaveBeenCalled();
+            expect(d3.selection.prototype.transition.calls.count()).toBe(1);
+
+            // now draw without animation
+            scatterGraph.drawElement(chart.d3Svg, chart.xRange, chart.yRange, chart.axisLabels, false);
+
+            // transition should not have been called again, so call count should remain 1
+            expect(d3.selection.prototype.transition.calls.count()).toBe(1);
+
+        });
     });
 });


### PR DESCRIPTION
Summary of changes:

Allow user to specify that they don't want axis padding when using
custom x and y ranges

Trigger zoom reset, so users can add listeners

Don't animate on regular zoom, since zoom already animates. This prevents
the laggy double animation on regular zoom (scroll zoom)

Added option to control scroll zoom independent of box zoom

Added sauce labs integration - it's almost working: test results
show up in the dashboard, but the success/failure status is not
being piped through.

Added some code to reduce size of jasmine report so Sauce labs
can handle it - now we have end-to-end integration working with
Sauce labs!
