### PR TITLE
Allow overriding y guide label tex

### DIFF
--- a/lib/views/LineGraph.js
+++ b/lib/views/LineGraph.js
@@ -12,6 +12,8 @@ class LineGraph extends Graph {
         // (since they're all in the guide layer)
         this.guideClassName = 'y_guide-' + this.id;
         this.guideColor = options.guideColor || this.color;
+        // allow overriding the guide text label property
+        this.guideLabelProp = options.guideLabelProp || 'y_value';
         this.interpolate = options.interpolate || 'linear';
     }
 
@@ -84,7 +86,8 @@ class LineGraph extends Graph {
         super.drawYLineGuide(yGuidesSelection, yGuidesEnterSelection, chart, {
             color: this.guideColor,
             xProp: 'x_value',
-            yProp: 'y_value'
+            yProp: 'y_value',
+            createLabelText: d => chart.yLabelFormat(d[this.guideLabelProp])
         });
 
         yGuidesSelection.exit().remove();

--- a/lib/views/ScatterGraph.js
+++ b/lib/views/ScatterGraph.js
@@ -133,6 +133,10 @@ class ScatterGraph extends Graph {
     // for a given x value, draws a guide line to the y axis (with y value in a box)
     drawYGuide(xValue, guideEl, chart) {
 
+        if (!this.guides) {
+            return;
+        }
+
         var point = this.dataSeries.data.find(p => p.x_value === xValue);
 
         var yGuidesData = [];

--- a/test/views/LineGraph.spec.js
+++ b/test/views/LineGraph.spec.js
@@ -23,9 +23,9 @@ function (
             });
 
             var data = [
-                {x_value: 0,   y_value: 100},
-                {x_value: 100, y_value: 0},
-                {x_value: 200, y_value: 100}
+                {x_value: 0,   y_value: 100, other_y: 200},
+                {x_value: 100, y_value: 0,   other_y: 300},
+                {x_value: 200, y_value: 100, other_y: 400}
             ];
 
             dataseries = new Nugget.NumericalDataSeries(data);
@@ -103,6 +103,34 @@ function (
 
             // transition should not have been called again, so call count should remain 1
             expect(d3.selection.prototype.transition.calls.count()).toBe(1);
+        });
+
+        it('should allow custom y axis guide label property', function() {
+            var guideEl = chart.d3Svg.append('g').attr('class', 'guide_layer');
+
+            line.guideLabelProp = 'other_y';
+            line.drawYGuide(100, guideEl, chart);
+
+            Utils.validateGuide($('.y_guide'), {
+                label: {
+                    text: '300',
+                    x: 93,
+                    y: 447
+                },
+                bg: {
+                    x: 69.5,
+                    y: 435.7,
+                    width: 26,
+                    height: 15
+                },
+                line: {
+                    x1: 100,
+                    y1: 440,
+                    x2: 295,
+                    y2: 440
+                }
+            });
+
         });
     });
 });


### PR DESCRIPTION
A couple of changes here:
1. Allow overriding property used for displaying text for YY guides
2. Respect guides: false in ScatterGraphs (discovered while working
   on something related)

Added test for custom y axis guide label property
