### PR TITLE
Shrinkwrap dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,2468 @@
+{
+  "name": "Nugget",
+  "version": "0.0.1",
+  "dependencies": {
+    "grunt-template-jasmine-requirejs": {
+      "version": "0.2.2",
+      "from": "grunt-template-jasmine-requirejs@0.2.2"
+    },
+    "grunt-contrib-clean": {
+      "version": "0.6.0",
+      "from": "grunt-contrib-clean@0.6.0",
+      "dependencies": {
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@~2.2.1"
+        }
+      }
+    },
+    "grunt-contrib-requirejs": {
+      "version": "0.4.4",
+      "from": "grunt-contrib-requirejs@0.4.4",
+      "dependencies": {
+        "requirejs": {
+          "version": "2.1.22",
+          "from": "requirejs@~2.1.0"
+        }
+      }
+    },
+    "grunt": {
+      "version": "0.4.5",
+      "from": "grunt@0.4.5",
+      "dependencies": {
+        "async": {
+          "version": "0.1.22",
+          "from": "async@~0.1.22"
+        },
+        "coffee-script": {
+          "version": "1.3.3",
+          "from": "coffee-script@~1.3.3"
+        },
+        "colors": {
+          "version": "0.6.2",
+          "from": "colors@~0.6.2"
+        },
+        "dateformat": {
+          "version": "1.0.2-1.2.3",
+          "from": "dateformat@1.0.2-1.2.3"
+        },
+        "eventemitter2": {
+          "version": "0.4.14",
+          "from": "eventemitter2@~0.4.13"
+        },
+        "findup-sync": {
+          "version": "0.1.3",
+          "from": "findup-sync@~0.1.2",
+          "dependencies": {
+            "glob": {
+              "version": "3.2.11",
+              "from": "glob@~3.2.9",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "minimatch": {
+                  "version": "0.3.0",
+                  "from": "minimatch@0.3",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@~2.4.1"
+            }
+          }
+        },
+        "glob": {
+          "version": "3.1.21",
+          "from": "glob@~3.1.21",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1.2.0"
+            },
+            "inherits": {
+              "version": "1.0.2",
+              "from": "inherits@1"
+            }
+          }
+        },
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@~0.2.3"
+        },
+        "iconv-lite": {
+          "version": "0.2.11",
+          "from": "iconv-lite@~0.2.11"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@~0.2.12",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.7.3",
+              "from": "lru-cache@2"
+            },
+            "sigmund": {
+              "version": "1.0.1",
+              "from": "sigmund@~1.0.0"
+            }
+          }
+        },
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@~1.0.10",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.7",
+              "from": "abbrev@1"
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@~2.2.8"
+        },
+        "lodash": {
+          "version": "0.9.2",
+          "from": "lodash@~0.9.2"
+        },
+        "underscore.string": {
+          "version": "2.2.1",
+          "from": "underscore.string@~2.2.1"
+        },
+        "which": {
+          "version": "1.0.9",
+          "from": "which@~1.0.5"
+        },
+        "js-yaml": {
+          "version": "2.0.5",
+          "from": "js-yaml@~2.0.5",
+          "dependencies": {
+            "argparse": {
+              "version": "0.1.16",
+              "from": "argparse@~ 0.1.11",
+              "dependencies": {
+                "underscore": {
+                  "version": "1.7.0",
+                  "from": "underscore@~1.7.0"
+                },
+                "underscore.string": {
+                  "version": "2.4.0",
+                  "from": "underscore.string@~2.4.0"
+                }
+              }
+            },
+            "esprima": {
+              "version": "1.0.4",
+              "from": "esprima@~ 1.0.2"
+            }
+          }
+        },
+        "exit": {
+          "version": "0.1.2",
+          "from": "exit@~0.1.1"
+        },
+        "getobject": {
+          "version": "0.1.0",
+          "from": "getobject@~0.1.0"
+        },
+        "grunt-legacy-util": {
+          "version": "0.2.0",
+          "from": "grunt-legacy-util@~0.2.0"
+        },
+        "grunt-legacy-log": {
+          "version": "0.1.3",
+          "from": "grunt-legacy-log@~0.1.0",
+          "dependencies": {
+            "grunt-legacy-log-utils": {
+              "version": "0.1.1",
+              "from": "grunt-legacy-log-utils@~0.1.1"
+            },
+            "lodash": {
+              "version": "2.4.2",
+              "from": "lodash@~2.4.1"
+            },
+            "underscore.string": {
+              "version": "2.3.3",
+              "from": "underscore.string@~2.3.3"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-watch": {
+      "version": "0.6.1",
+      "from": "grunt-contrib-watch@0.6.1",
+      "dependencies": {
+        "gaze": {
+          "version": "0.5.2",
+          "from": "gaze@~0.5.1",
+          "dependencies": {
+            "globule": {
+              "version": "0.1.0",
+              "from": "globule@~0.1.0",
+              "dependencies": {
+                "lodash": {
+                  "version": "1.0.2",
+                  "from": "lodash@~1.0.1"
+                },
+                "glob": {
+                  "version": "3.1.21",
+                  "from": "glob@~3.1.21",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "1.2.3",
+                      "from": "graceful-fs@~1.2.0"
+                    },
+                    "inherits": {
+                      "version": "1.0.2",
+                      "from": "inherits@1"
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.14",
+                  "from": "minimatch@~0.2.11",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.7.3",
+                      "from": "lru-cache@2"
+                    },
+                    "sigmund": {
+                      "version": "1.0.1",
+                      "from": "sigmund@~1.0.0"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "tiny-lr-fork": {
+          "version": "0.0.5",
+          "from": "tiny-lr-fork@0.0.5",
+          "dependencies": {
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@~0.5.2"
+            },
+            "faye-websocket": {
+              "version": "0.4.4",
+              "from": "faye-websocket@~0.4.3"
+            },
+            "noptify": {
+              "version": "0.0.3",
+              "from": "noptify@~0.0.3",
+              "dependencies": {
+                "nopt": {
+                  "version": "2.0.0",
+                  "from": "nopt@~2.0.0",
+                  "dependencies": {
+                    "abbrev": {
+                      "version": "1.0.7",
+                      "from": "abbrev@1"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@~0.7.0"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@~2.4.1"
+        },
+        "async": {
+          "version": "0.2.10",
+          "from": "async@~0.2.9"
+        }
+      }
+    },
+    "grunt-contrib-connect": {
+      "version": "0.9.0",
+      "from": "grunt-contrib-connect@0.9.0",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@^0.9.0"
+        },
+        "connect": {
+          "version": "2.30.2",
+          "from": "connect@^2.27.1",
+          "dependencies": {
+            "basic-auth-connect": {
+              "version": "1.0.0",
+              "from": "basic-auth-connect@1.0.0"
+            },
+            "body-parser": {
+              "version": "1.13.3",
+              "from": "body-parser@~1.13.3",
+              "dependencies": {
+                "iconv-lite": {
+                  "version": "0.4.11",
+                  "from": "iconv-lite@0.4.11"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@~2.3.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1"
+                    }
+                  }
+                },
+                "raw-body": {
+                  "version": "2.1.5",
+                  "from": "raw-body@~2.1.2",
+                  "dependencies": {
+                    "bytes": {
+                      "version": "2.2.0",
+                      "from": "bytes@2.2.0"
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.13",
+                      "from": "iconv-lite@0.4.13"
+                    },
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "from": "unpipe@1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "bytes": {
+              "version": "2.1.0",
+              "from": "bytes@2.1.0"
+            },
+            "cookie": {
+              "version": "0.1.3",
+              "from": "cookie@0.1.3"
+            },
+            "cookie-parser": {
+              "version": "1.3.5",
+              "from": "cookie-parser@~1.3.5"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6"
+            },
+            "compression": {
+              "version": "1.5.2",
+              "from": "compression@~1.5.2",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.2.13",
+                  "from": "accepts@~1.2.12",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.9",
+                      "from": "mime-types@~2.1.7",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.21.0",
+                          "from": "mime-db@~1.21.0"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.5.3",
+                      "from": "negotiator@0.5.3"
+                    }
+                  }
+                },
+                "compressible": {
+                  "version": "2.0.7",
+                  "from": "compressible@~2.0.5",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0"
+                    }
+                  }
+                },
+                "vary": {
+                  "version": "1.0.1",
+                  "from": "vary@~1.0.1"
+                }
+              }
+            },
+            "connect-timeout": {
+              "version": "1.6.2",
+              "from": "connect-timeout@~1.6.2",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "content-type": {
+              "version": "1.0.1",
+              "from": "content-type@~1.0.1"
+            },
+            "csurf": {
+              "version": "1.8.3",
+              "from": "csurf@~1.8.3",
+              "dependencies": {
+                "csrf": {
+                  "version": "3.0.0",
+                  "from": "csrf@~3.0.0",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1"
+                    },
+                    "rndm": {
+                      "version": "1.1.1",
+                      "from": "rndm@~1.1.0"
+                    },
+                    "scmp": {
+                      "version": "1.0.0",
+                      "from": "scmp@1.0.0"
+                    },
+                    "uid-safe": {
+                      "version": "2.0.0",
+                      "from": "uid-safe@~2.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@~2.2.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.0.1",
+              "from": "depd@~1.0.1"
+            },
+            "errorhandler": {
+              "version": "1.4.3",
+              "from": "errorhandler@~1.4.2",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.3.0",
+                  "from": "accepts@~1.3.0",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.9",
+                      "from": "mime-types@~2.1.7",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.21.0",
+                          "from": "mime-db@~1.21.0"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.6.0",
+                      "from": "negotiator@0.6.0"
+                    }
+                  }
+                },
+                "escape-html": {
+                  "version": "1.0.3",
+                  "from": "escape-html@~1.0.3"
+                }
+              }
+            },
+            "express-session": {
+              "version": "1.11.3",
+              "from": "express-session@~1.11.3",
+              "dependencies": {
+                "crc": {
+                  "version": "3.3.0",
+                  "from": "crc@3.3.0"
+                },
+                "uid-safe": {
+                  "version": "2.0.0",
+                  "from": "uid-safe@~2.0.0",
+                  "dependencies": {
+                    "base64-url": {
+                      "version": "1.2.1",
+                      "from": "base64-url@1.2.1"
+                    }
+                  }
+                }
+              }
+            },
+            "finalhandler": {
+              "version": "0.4.0",
+              "from": "finalhandler@0.4.0",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@~2.3.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1"
+                    }
+                  }
+                },
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@~1.0.0"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.3.0",
+              "from": "fresh@0.3.0"
+            },
+            "http-errors": {
+              "version": "1.3.1",
+              "from": "http-errors@~1.3.1",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1"
+                },
+                "statuses": {
+                  "version": "1.2.1",
+                  "from": "statuses@1"
+                }
+              }
+            },
+            "method-override": {
+              "version": "2.3.5",
+              "from": "method-override@~2.3.5",
+              "dependencies": {
+                "methods": {
+                  "version": "1.1.2",
+                  "from": "methods@~1.1.1"
+                },
+                "vary": {
+                  "version": "1.0.1",
+                  "from": "vary@~1.0.1"
+                }
+              }
+            },
+            "morgan": {
+              "version": "1.6.1",
+              "from": "morgan@~1.6.1",
+              "dependencies": {
+                "basic-auth": {
+                  "version": "1.0.3",
+                  "from": "basic-auth@~1.0.3"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@~2.3.0",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1"
+                    }
+                  }
+                }
+              }
+            },
+            "multiparty": {
+              "version": "3.3.2",
+              "from": "multiparty@3.3.2",
+              "dependencies": {
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@~1.1.9",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1"
+                    }
+                  }
+                },
+                "stream-counter": {
+                  "version": "0.2.0",
+                  "from": "stream-counter@~0.2.0"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "on-headers@~1.0.0"
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@~1.3.0"
+            },
+            "pause": {
+              "version": "0.1.0",
+              "from": "pause@0.1.0"
+            },
+            "qs": {
+              "version": "4.0.0",
+              "from": "qs@4.0.0"
+            },
+            "response-time": {
+              "version": "2.3.1",
+              "from": "response-time@~2.3.1"
+            },
+            "serve-favicon": {
+              "version": "2.3.0",
+              "from": "serve-favicon@~2.3.0",
+              "dependencies": {
+                "etag": {
+                  "version": "1.7.0",
+                  "from": "etag@~1.7.0"
+                },
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "serve-index": {
+              "version": "1.7.2",
+              "from": "serve-index@~1.7.2",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.2.13",
+                  "from": "accepts@~1.2.12",
+                  "dependencies": {
+                    "negotiator": {
+                      "version": "0.5.3",
+                      "from": "negotiator@0.5.3"
+                    }
+                  }
+                },
+                "batch": {
+                  "version": "0.5.2",
+                  "from": "batch@0.5.2"
+                },
+                "escape-html": {
+                  "version": "1.0.2",
+                  "from": "escape-html@1.0.2"
+                },
+                "mime-types": {
+                  "version": "2.1.9",
+                  "from": "mime-types@~2.1.4",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0"
+                    }
+                  }
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.10.1",
+              "from": "serve-static@~1.10.0",
+              "dependencies": {
+                "escape-html": {
+                  "version": "1.0.3",
+                  "from": "escape-html@~1.0.3"
+                },
+                "send": {
+                  "version": "0.13.1",
+                  "from": "send@0.13.1",
+                  "dependencies": {
+                    "depd": {
+                      "version": "1.1.0",
+                      "from": "depd@~1.1.0"
+                    },
+                    "destroy": {
+                      "version": "1.0.4",
+                      "from": "destroy@~1.0.4"
+                    },
+                    "etag": {
+                      "version": "1.7.0",
+                      "from": "etag@~1.7.0"
+                    },
+                    "mime": {
+                      "version": "1.3.4",
+                      "from": "mime@1.3.4"
+                    },
+                    "ms": {
+                      "version": "0.7.1",
+                      "from": "ms@0.7.1"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "from": "on-finished@~2.3.0",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1",
+                          "from": "ee-first@1.1.1"
+                        }
+                      }
+                    },
+                    "range-parser": {
+                      "version": "1.0.3",
+                      "from": "range-parser@~1.0.3"
+                    },
+                    "statuses": {
+                      "version": "1.2.1",
+                      "from": "statuses@~1.2.1"
+                    }
+                  }
+                }
+              }
+            },
+            "type-is": {
+              "version": "1.6.10",
+              "from": "type-is@~1.6.6",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0"
+                },
+                "mime-types": {
+                  "version": "2.1.9",
+                  "from": "mime-types@~2.1.8",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.21.0",
+                      "from": "mime-db@~1.21.0"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0"
+            },
+            "vhost": {
+              "version": "3.0.2",
+              "from": "vhost@~3.0.1"
+            }
+          }
+        },
+        "connect-livereload": {
+          "version": "0.5.4",
+          "from": "connect-livereload@^0.5.0"
+        },
+        "opn": {
+          "version": "1.0.2",
+          "from": "opn@^1.0.0"
+        },
+        "portscanner": {
+          "version": "1.0.0",
+          "from": "portscanner@^1.0.0",
+          "dependencies": {
+            "async": {
+              "version": "0.1.15",
+              "from": "async@0.1.15"
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-jshint": {
+      "version": "0.11.1",
+      "from": "grunt-contrib-jshint@0.11.1",
+      "dependencies": {
+        "hooker": {
+          "version": "0.2.3",
+          "from": "hooker@^0.2.3"
+        },
+        "jshint": {
+          "version": "2.9.1",
+          "from": "jshint@^2.6.0",
+          "dependencies": {
+            "cli": {
+              "version": "0.6.6",
+              "from": "cli@0.6.x",
+              "dependencies": {
+                "glob": {
+                  "version": "3.2.11",
+                  "from": "glob@~ 3.2.1",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@2"
+                    },
+                    "minimatch": {
+                      "version": "0.3.0",
+                      "from": "minimatch@0.3",
+                      "dependencies": {
+                        "lru-cache": {
+                          "version": "2.7.3",
+                          "from": "lru-cache@2"
+                        },
+                        "sigmund": {
+                          "version": "1.0.1",
+                          "from": "sigmund@~1.0.0"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@1.1.x",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@^0.1.4"
+                }
+              }
+            },
+            "exit": {
+              "version": "0.1.2",
+              "from": "exit@0.1.x"
+            },
+            "htmlparser2": {
+              "version": "3.8.3",
+              "from": "htmlparser2@3.8.x",
+              "dependencies": {
+                "domhandler": {
+                  "version": "2.3.0",
+                  "from": "domhandler@2.3"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@1.5",
+                  "dependencies": {
+                    "dom-serializer": {
+                      "version": "0.1.0",
+                      "from": "dom-serializer@0",
+                      "dependencies": {
+                        "domelementtype": {
+                          "version": "1.1.3",
+                          "from": "domelementtype@~1.1.1"
+                        },
+                        "entities": {
+                          "version": "1.1.1",
+                          "from": "entities@~1.1.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@1"
+                },
+                "readable-stream": {
+                  "version": "1.1.13",
+                  "from": "readable-stream@1.1",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@~1.0.0"
+                    },
+                    "isarray": {
+                      "version": "0.0.1",
+                      "from": "isarray@0.0.1"
+                    },
+                    "string_decoder": {
+                      "version": "0.10.31",
+                      "from": "string_decoder@~0.10.x"
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.1"
+                    }
+                  }
+                },
+                "entities": {
+                  "version": "1.0.0",
+                  "from": "entities@1.0"
+                }
+              }
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@2.0.x",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.2",
+                  "from": "brace-expansion@^1.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@^0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "shelljs": {
+              "version": "0.3.0",
+              "from": "shelljs@0.3.x"
+            },
+            "strip-json-comments": {
+              "version": "1.0.4",
+              "from": "strip-json-comments@1.0.x"
+            },
+            "lodash": {
+              "version": "3.7.0",
+              "from": "lodash@3.7.x"
+            }
+          }
+        }
+      }
+    },
+    "grunt-saucelabs": {
+      "version": "8.6.2",
+      "from": "grunt-saucelabs@*",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@~1.0.0"
+        },
+        "lodash": {
+          "version": "3.7.0",
+          "from": "lodash@~3.7.0"
+        },
+        "q": {
+          "version": "1.3.0",
+          "from": "q@~1.3.0"
+        },
+        "requestretry": {
+          "version": "1.2.2",
+          "from": "requestretry@~1.2.2",
+          "dependencies": {
+            "fg-lodash": {
+              "version": "0.0.2",
+              "from": "fg-lodash@0.0.2",
+              "dependencies": {
+                "lodash": {
+                  "version": "2.4.2",
+                  "from": "lodash@^2.4.1"
+                },
+                "underscore.string": {
+                  "version": "2.3.3",
+                  "from": "underscore.string@~2.3.3"
+                }
+              }
+            },
+            "request": {
+              "version": "2.51.0",
+              "from": "request@2.51.x",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.5",
+                  "from": "bl@~0.9.0",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@~1.0.26",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@~1.0.0"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@~0.10.x"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@~2.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.8.0",
+                  "from": "caseless@~0.8.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@~0.2.0",
+                  "dependencies": {
+                    "async": {
+                      "version": "0.9.2",
+                      "from": "async@~0.9.0"
+                    },
+                    "mime-types": {
+                      "version": "2.0.14",
+                      "from": "mime-types@~2.0.3",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.12.0",
+                          "from": "mime-db@~1.12.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@~5.0.0"
+                },
+                "mime-types": {
+                  "version": "1.0.2",
+                  "from": "mime-types@~1.0.1"
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "qs": {
+                  "version": "2.3.3",
+                  "from": "qs@~2.3.1"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.2",
+                  "from": "tunnel-agent@~0.4.0"
+                },
+                "tough-cookie": {
+                  "version": "2.2.1",
+                  "from": "tough-cookie@>=0.12.0"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@~0.10.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@^0.1.5"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.5.0",
+                  "from": "oauth-sign@~0.5.0"
+                },
+                "hawk": {
+                  "version": "1.1.1",
+                  "from": "hawk@1.1.1",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.9.1",
+                      "from": "hoek@0.9.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x"
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@~0.5.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@~0.0.4"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "sauce-tunnel": {
+          "version": "2.3.0",
+          "from": "sauce-tunnel@~2.3.0",
+          "dependencies": {
+            "chalk": {
+              "version": "1.0.0",
+              "from": "chalk@~1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.0.1"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@^1.0.2"
+                },
+                "has-ansi": {
+                  "version": "1.0.3",
+                  "from": "has-ansi@^1.0.3",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0"
+                    },
+                    "get-stdin": {
+                      "version": "4.0.1",
+                      "from": "get-stdin@^4.0.1"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "2.0.1",
+                  "from": "strip-ansi@^2.0.1",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "1.1.1",
+                      "from": "ansi-regex@^1.1.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "1.3.1",
+                  "from": "supports-color@^1.3.0"
+                }
+              }
+            },
+            "request": {
+              "version": "2.21.0",
+              "from": "request@~2.21.0",
+              "dependencies": {
+                "qs": {
+                  "version": "0.6.6",
+                  "from": "qs@~0.6.0"
+                },
+                "json-stringify-safe": {
+                  "version": "4.0.0",
+                  "from": "json-stringify-safe@~4.0.0"
+                },
+                "forever-agent": {
+                  "version": "0.5.2",
+                  "from": "forever-agent@~0.5.0"
+                },
+                "tunnel-agent": {
+                  "version": "0.3.0",
+                  "from": "tunnel-agent@~0.3.0"
+                },
+                "http-signature": {
+                  "version": "0.9.11",
+                  "from": "http-signature@~0.9.11",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.2",
+                      "from": "assert-plus@0.1.2"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11"
+                    },
+                    "ctype": {
+                      "version": "0.5.2",
+                      "from": "ctype@0.5.2"
+                    }
+                  }
+                },
+                "hawk": {
+                  "version": "0.13.1",
+                  "from": "hawk@~0.13.0",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "0.8.5",
+                      "from": "hoek@0.8.x"
+                    },
+                    "boom": {
+                      "version": "0.4.2",
+                      "from": "boom@0.4.x",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x"
+                        }
+                      }
+                    },
+                    "cryptiles": {
+                      "version": "0.2.2",
+                      "from": "cryptiles@0.2.x"
+                    },
+                    "sntp": {
+                      "version": "0.2.4",
+                      "from": "sntp@0.2.x",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x"
+                        }
+                      }
+                    }
+                  }
+                },
+                "aws-sign": {
+                  "version": "0.3.0",
+                  "from": "aws-sign@~0.3.0"
+                },
+                "oauth-sign": {
+                  "version": "0.3.0",
+                  "from": "oauth-sign@~0.3.0"
+                },
+                "cookie-jar": {
+                  "version": "0.3.0",
+                  "from": "cookie-jar@~0.3.0"
+                },
+                "node-uuid": {
+                  "version": "1.4.7",
+                  "from": "node-uuid@~1.4.0"
+                },
+                "mime": {
+                  "version": "1.2.11",
+                  "from": "mime@~1.2.9"
+                },
+                "form-data": {
+                  "version": "0.0.8",
+                  "from": "form-data@0.0.8",
+                  "dependencies": {
+                    "combined-stream": {
+                      "version": "0.0.7",
+                      "from": "combined-stream@~0.0.4",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "0.0.5",
+                          "from": "delayed-stream@0.0.5"
+                        }
+                      }
+                    },
+                    "async": {
+                      "version": "0.2.10",
+                      "from": "async@~0.2.7"
+                    }
+                  }
+                }
+              }
+            },
+            "split": {
+              "version": "0.3.3",
+              "from": "split@~0.3.2",
+              "dependencies": {
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@2"
+                }
+              }
+            }
+          }
+        },
+        "saucelabs": {
+          "version": "0.1.1",
+          "from": "saucelabs@~0.1.1"
+        }
+      }
+    },
+    "load-grunt-tasks": {
+      "version": "3.1.0",
+      "from": "load-grunt-tasks@3.1.0",
+      "dependencies": {
+        "findup-sync": {
+          "version": "0.2.1",
+          "from": "findup-sync@^0.2.1",
+          "dependencies": {
+            "glob": {
+              "version": "4.3.5",
+              "from": "glob@~4.3.0",
+              "dependencies": {
+                "inflight": {
+                  "version": "1.0.4",
+                  "from": "inflight@^1.0.4",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2"
+                },
+                "minimatch": {
+                  "version": "2.0.10",
+                  "from": "minimatch@^2.0.1",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.2",
+                      "from": "brace-expansion@^1.0.0",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "0.3.0",
+                          "from": "balanced-match@^0.3.0"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1"
+                        }
+                      }
+                    }
+                  }
+                },
+                "once": {
+                  "version": "1.3.3",
+                  "from": "once@^1.3.0",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.1",
+                      "from": "wrappy@1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "multimatch": {
+          "version": "2.1.0",
+          "from": "multimatch@^2.0.0",
+          "dependencies": {
+            "array-differ": {
+              "version": "1.0.0",
+              "from": "array-differ@^1.0.0"
+            },
+            "array-union": {
+              "version": "1.0.1",
+              "from": "array-union@^1.0.1",
+              "dependencies": {
+                "array-uniq": {
+                  "version": "1.0.2",
+                  "from": "array-uniq@^1.0.1"
+                }
+              }
+            },
+            "arrify": {
+              "version": "1.0.1",
+              "from": "arrify@^1.0.0"
+            },
+            "minimatch": {
+              "version": "3.0.0",
+              "from": "minimatch@^3.0.0",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.2",
+                  "from": "brace-expansion@^1.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@^0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "grunt-contrib-jasmine": {
+      "version": "0.8.2",
+      "from": "grunt-contrib-jasmine@0.8.2",
+      "dependencies": {
+        "grunt-lib-phantomjs": {
+          "version": "0.6.0",
+          "from": "grunt-lib-phantomjs@^0.6.0",
+          "dependencies": {
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@~0.4.9"
+            },
+            "semver": {
+              "version": "1.0.14",
+              "from": "semver@~1.0.14"
+            },
+            "temporary": {
+              "version": "0.0.8",
+              "from": "temporary@~0.0.4",
+              "dependencies": {
+                "package": {
+                  "version": "1.0.1",
+                  "from": "package@>= 1.0.0 < 1.2.0"
+                }
+              }
+            },
+            "phantomjs": {
+              "version": "1.9.19",
+              "from": "phantomjs@~1.9.0-1",
+              "dependencies": {
+                "adm-zip": {
+                  "version": "0.4.4",
+                  "from": "adm-zip@0.4.4"
+                },
+                "fs-extra": {
+                  "version": "0.23.1",
+                  "from": "fs-extra@~0.23.1",
+                  "dependencies": {
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@^4.1.2"
+                    },
+                    "jsonfile": {
+                      "version": "2.2.3",
+                      "from": "jsonfile@^2.1.0"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.0",
+                      "from": "path-is-absolute@^1.0.0"
+                    },
+                    "rimraf": {
+                      "version": "2.5.0",
+                      "from": "rimraf@^2.2.8",
+                      "dependencies": {
+                        "glob": {
+                          "version": "6.0.4",
+                          "from": "glob@^6.0.1",
+                          "dependencies": {
+                            "inflight": {
+                              "version": "1.0.4",
+                              "from": "inflight@^1.0.4",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1"
+                                }
+                              }
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@2"
+                            },
+                            "minimatch": {
+                              "version": "3.0.0",
+                              "from": "minimatch@2 || 3",
+                              "dependencies": {
+                                "brace-expansion": {
+                                  "version": "1.1.2",
+                                  "from": "brace-expansion@^1.0.0",
+                                  "dependencies": {
+                                    "balanced-match": {
+                                      "version": "0.3.0",
+                                      "from": "balanced-match@^0.3.0"
+                                    },
+                                    "concat-map": {
+                                      "version": "0.0.1",
+                                      "from": "concat-map@0.0.1"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "once": {
+                              "version": "1.3.3",
+                              "from": "once@^1.3.0",
+                              "dependencies": {
+                                "wrappy": {
+                                  "version": "1.0.1",
+                                  "from": "wrappy@1"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "kew": {
+                  "version": "0.4.0",
+                  "from": "kew@0.4.0"
+                },
+                "md5": {
+                  "version": "2.0.0",
+                  "from": "md5@~2.0.0",
+                  "dependencies": {
+                    "charenc": {
+                      "version": "0.0.1",
+                      "from": "charenc@~ 0.0.1"
+                    },
+                    "crypt": {
+                      "version": "0.0.1",
+                      "from": "crypt@~ 0.0.1"
+                    },
+                    "is-buffer": {
+                      "version": "1.0.2",
+                      "from": "is-buffer@~ 1.0.2"
+                    }
+                  }
+                },
+                "npmconf": {
+                  "version": "2.1.1",
+                  "from": "npmconf@2.1.1",
+                  "dependencies": {
+                    "config-chain": {
+                      "version": "1.1.10",
+                      "from": "config-chain@~1.1.8",
+                      "dependencies": {
+                        "proto-list": {
+                          "version": "1.2.4",
+                          "from": "proto-list@~1.2.1"
+                        }
+                      }
+                    },
+                    "inherits": {
+                      "version": "2.0.1",
+                      "from": "inherits@~2.0.0"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@^1.2.0"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@^0.5.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8"
+                        }
+                      }
+                    },
+                    "nopt": {
+                      "version": "3.0.6",
+                      "from": "nopt@~3.0.1",
+                      "dependencies": {
+                        "abbrev": {
+                          "version": "1.0.7",
+                          "from": "abbrev@1"
+                        }
+                      }
+                    },
+                    "once": {
+                      "version": "1.3.3",
+                      "from": "once@~1.3.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.1",
+                          "from": "wrappy@1"
+                        }
+                      }
+                    },
+                    "osenv": {
+                      "version": "0.1.3",
+                      "from": "osenv@^0.1.0",
+                      "dependencies": {
+                        "os-homedir": {
+                          "version": "1.0.1",
+                          "from": "os-homedir@^1.0.0"
+                        },
+                        "os-tmpdir": {
+                          "version": "1.0.1",
+                          "from": "os-tmpdir@^1.0.0"
+                        }
+                      }
+                    },
+                    "semver": {
+                      "version": "4.3.6",
+                      "from": "semver@2 || 3 || 4"
+                    },
+                    "uid-number": {
+                      "version": "0.0.5",
+                      "from": "uid-number@0.0.5"
+                    }
+                  }
+                },
+                "progress": {
+                  "version": "1.1.8",
+                  "from": "progress@1.1.8"
+                },
+                "request": {
+                  "version": "2.42.0",
+                  "from": "request@2.42.0",
+                  "dependencies": {
+                    "bl": {
+                      "version": "0.9.5",
+                      "from": "bl@~0.9.0",
+                      "dependencies": {
+                        "readable-stream": {
+                          "version": "1.0.33",
+                          "from": "readable-stream@~1.0.26",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x"
+                            },
+                            "inherits": {
+                              "version": "2.0.1",
+                              "from": "inherits@~2.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "caseless": {
+                      "version": "0.6.0",
+                      "from": "caseless@~0.6.0"
+                    },
+                    "forever-agent": {
+                      "version": "0.5.2",
+                      "from": "forever-agent@~0.5.0"
+                    },
+                    "qs": {
+                      "version": "1.2.2",
+                      "from": "qs@~1.2.0"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.0"
+                    },
+                    "mime-types": {
+                      "version": "1.0.2",
+                      "from": "mime-types@~1.0.1"
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.0"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.2",
+                      "from": "tunnel-agent@~0.4.0"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.1",
+                      "from": "tough-cookie@>=0.12.0"
+                    },
+                    "form-data": {
+                      "version": "0.1.4",
+                      "from": "form-data@~0.1.0",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "from": "combined-stream@~0.0.4",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5"
+                            }
+                          }
+                        },
+                        "mime": {
+                          "version": "1.2.11",
+                          "from": "mime@~1.2.11"
+                        },
+                        "async": {
+                          "version": "0.9.2",
+                          "from": "async@~0.9.0"
+                        }
+                      }
+                    },
+                    "http-signature": {
+                      "version": "0.10.1",
+                      "from": "http-signature@~0.10.0",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "0.1.5",
+                          "from": "assert-plus@^0.1.5"
+                        },
+                        "asn1": {
+                          "version": "0.1.11",
+                          "from": "asn1@0.1.11"
+                        },
+                        "ctype": {
+                          "version": "0.5.3",
+                          "from": "ctype@0.5.3"
+                        }
+                      }
+                    },
+                    "oauth-sign": {
+                      "version": "0.4.0",
+                      "from": "oauth-sign@~0.4.0"
+                    },
+                    "hawk": {
+                      "version": "1.1.1",
+                      "from": "hawk@1.1.1",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.9.1",
+                          "from": "hoek@0.9.x"
+                        },
+                        "boom": {
+                          "version": "0.4.2",
+                          "from": "boom@0.4.x"
+                        },
+                        "cryptiles": {
+                          "version": "0.2.2",
+                          "from": "cryptiles@0.2.x"
+                        },
+                        "sntp": {
+                          "version": "0.2.4",
+                          "from": "sntp@0.2.x"
+                        }
+                      }
+                    },
+                    "aws-sign2": {
+                      "version": "0.5.0",
+                      "from": "aws-sign2@~0.5.0"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@~0.0.4"
+                    }
+                  }
+                },
+                "request-progress": {
+                  "version": "0.3.1",
+                  "from": "request-progress@0.3.1",
+                  "dependencies": {
+                    "throttleit": {
+                      "version": "0.0.2",
+                      "from": "throttleit@~0.0.2"
+                    }
+                  }
+                },
+                "which": {
+                  "version": "1.0.9",
+                  "from": "which@~1.0.5"
+                }
+              }
+            }
+          }
+        },
+        "rimraf": {
+          "version": "2.1.4",
+          "from": "rimraf@~2.1.4",
+          "dependencies": {
+            "graceful-fs": {
+              "version": "1.2.3",
+              "from": "graceful-fs@~1"
+            }
+          }
+        },
+        "chalk": {
+          "version": "0.4.0",
+          "from": "chalk@~0.4.0",
+          "dependencies": {
+            "has-color": {
+              "version": "0.1.7",
+              "from": "has-color@~0.1.0"
+            },
+            "ansi-styles": {
+              "version": "1.0.0",
+              "from": "ansi-styles@~1.0.0"
+            },
+            "strip-ansi": {
+              "version": "0.1.1",
+              "from": "strip-ansi@~0.1.0"
+            }
+          }
+        },
+        "lodash": {
+          "version": "2.4.2",
+          "from": "lodash@~2.4.1"
+        },
+        "es5-shim": {
+          "version": "4.0.6",
+          "from": "es5-shim@~4.0.1"
+        },
+        "jasmine-core": {
+          "version": "2.4.1",
+          "from": "jasmine-core@>=2.0.4"
+        }
+      }
+    },
+    "grunt-babel": {
+      "version": "5.0.1",
+      "from": "grunt-babel@5.0.1",
+      "dependencies": {
+        "babel-core": {
+          "version": "5.8.34",
+          "from": "babel-core@^5.0.0",
+          "dependencies": {
+            "babel-plugin-constant-folding": {
+              "version": "1.0.1",
+              "from": "babel-plugin-constant-folding@^1.0.1"
+            },
+            "babel-plugin-dead-code-elimination": {
+              "version": "1.0.2",
+              "from": "babel-plugin-dead-code-elimination@^1.0.2"
+            },
+            "babel-plugin-eval": {
+              "version": "1.0.1",
+              "from": "babel-plugin-eval@^1.0.1"
+            },
+            "babel-plugin-inline-environment-variables": {
+              "version": "1.0.1",
+              "from": "babel-plugin-inline-environment-variables@^1.0.1"
+            },
+            "babel-plugin-jscript": {
+              "version": "1.0.4",
+              "from": "babel-plugin-jscript@^1.0.4"
+            },
+            "babel-plugin-member-expression-literals": {
+              "version": "1.0.1",
+              "from": "babel-plugin-member-expression-literals@^1.0.1"
+            },
+            "babel-plugin-property-literals": {
+              "version": "1.0.1",
+              "from": "babel-plugin-property-literals@^1.0.1"
+            },
+            "babel-plugin-proto-to-assign": {
+              "version": "1.0.4",
+              "from": "babel-plugin-proto-to-assign@^1.0.3"
+            },
+            "babel-plugin-react-constant-elements": {
+              "version": "1.0.3",
+              "from": "babel-plugin-react-constant-elements@^1.0.3"
+            },
+            "babel-plugin-react-display-name": {
+              "version": "1.0.3",
+              "from": "babel-plugin-react-display-name@^1.0.3"
+            },
+            "babel-plugin-remove-console": {
+              "version": "1.0.1",
+              "from": "babel-plugin-remove-console@^1.0.1"
+            },
+            "babel-plugin-remove-debugger": {
+              "version": "1.0.1",
+              "from": "babel-plugin-remove-debugger@^1.0.1"
+            },
+            "babel-plugin-runtime": {
+              "version": "1.0.7",
+              "from": "babel-plugin-runtime@^1.0.7"
+            },
+            "babel-plugin-undeclared-variables-check": {
+              "version": "1.0.2",
+              "from": "babel-plugin-undeclared-variables-check@^1.0.2",
+              "dependencies": {
+                "leven": {
+                  "version": "1.0.2",
+                  "from": "leven@^1.0.2"
+                }
+              }
+            },
+            "babel-plugin-undefined-to-void": {
+              "version": "1.1.6",
+              "from": "babel-plugin-undefined-to-void@^1.1.6"
+            },
+            "babylon": {
+              "version": "5.8.34",
+              "from": "babylon@^5.8.34"
+            },
+            "bluebird": {
+              "version": "2.10.2",
+              "from": "bluebird@^2.9.33"
+            },
+            "chalk": {
+              "version": "1.1.1",
+              "from": "chalk@^1.0.0",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.1.0",
+                  "from": "ansi-styles@^2.1.0"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.4",
+                  "from": "escape-string-regexp@^1.0.2"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.0",
+                  "from": "strip-ansi@^3.0.0",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.0.0",
+                      "from": "ansi-regex@^2.0.0"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0"
+                }
+              }
+            },
+            "convert-source-map": {
+              "version": "1.1.3",
+              "from": "convert-source-map@^1.1.0"
+            },
+            "core-js": {
+              "version": "1.2.6",
+              "from": "core-js@^1.0.0"
+            },
+            "debug": {
+              "version": "2.2.0",
+              "from": "debug@^2.1.1",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.1",
+                  "from": "ms@0.7.1"
+                }
+              }
+            },
+            "detect-indent": {
+              "version": "3.0.1",
+              "from": "detect-indent@^3.0.0",
+              "dependencies": {
+                "get-stdin": {
+                  "version": "4.0.1",
+                  "from": "get-stdin@^4.0.1"
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@^1.1.0"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@^2.0.0"
+            },
+            "fs-readdir-recursive": {
+              "version": "0.1.2",
+              "from": "fs-readdir-recursive@^0.1.0"
+            },
+            "globals": {
+              "version": "6.4.1",
+              "from": "globals@^6.4.0"
+            },
+            "home-or-tmp": {
+              "version": "1.0.0",
+              "from": "home-or-tmp@^1.0.0",
+              "dependencies": {
+                "os-tmpdir": {
+                  "version": "1.0.1",
+                  "from": "os-tmpdir@^1.0.1"
+                },
+                "user-home": {
+                  "version": "1.1.1",
+                  "from": "user-home@^1.1.1"
+                }
+              }
+            },
+            "is-integer": {
+              "version": "1.0.6",
+              "from": "is-integer@^1.0.4",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@^1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@^1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "js-tokens": {
+              "version": "1.0.1",
+              "from": "js-tokens@1.0.1"
+            },
+            "json5": {
+              "version": "0.4.0",
+              "from": "json5@^0.4.0"
+            },
+            "line-numbers": {
+              "version": "0.2.0",
+              "from": "line-numbers@0.2.0",
+              "dependencies": {
+                "left-pad": {
+                  "version": "0.0.3",
+                  "from": "left-pad@0.0.3"
+                }
+              }
+            },
+            "lodash": {
+              "version": "3.10.1",
+              "from": "lodash@^3.10.0"
+            },
+            "minimatch": {
+              "version": "2.0.10",
+              "from": "minimatch@^2.0.3",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.2",
+                  "from": "brace-expansion@^1.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.3.0",
+                      "from": "balanced-match@^0.3.0"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "output-file-sync": {
+              "version": "1.1.1",
+              "from": "output-file-sync@^1.1.0",
+              "dependencies": {
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@^0.5.1",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8"
+                    }
+                  }
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@^4.0.0"
+                }
+              }
+            },
+            "path-exists": {
+              "version": "1.0.0",
+              "from": "path-exists@^1.0.0"
+            },
+            "path-is-absolute": {
+              "version": "1.0.0",
+              "from": "path-is-absolute@^1.0.0"
+            },
+            "private": {
+              "version": "0.1.6",
+              "from": "private@^0.1.6"
+            },
+            "regenerator": {
+              "version": "0.8.40",
+              "from": "regenerator@0.8.40",
+              "dependencies": {
+                "commoner": {
+                  "version": "0.10.4",
+                  "from": "commoner@~0.10.3",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.5.0",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>= 1.0.0"
+                        }
+                      }
+                    },
+                    "detective": {
+                      "version": "4.3.1",
+                      "from": "detective@^4.3.1",
+                      "dependencies": {
+                        "acorn": {
+                          "version": "1.2.2",
+                          "from": "acorn@^1.0.3"
+                        },
+                        "defined": {
+                          "version": "1.0.0",
+                          "from": "defined@^1.0.0"
+                        }
+                      }
+                    },
+                    "glob": {
+                      "version": "5.0.15",
+                      "from": "glob@^5.0.15",
+                      "dependencies": {
+                        "inflight": {
+                          "version": "1.0.4",
+                          "from": "inflight@^1.0.4",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1"
+                            }
+                          }
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@2"
+                        },
+                        "once": {
+                          "version": "1.3.3",
+                          "from": "once@^1.3.0",
+                          "dependencies": {
+                            "wrappy": {
+                              "version": "1.0.1",
+                              "from": "wrappy@1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.2",
+                      "from": "graceful-fs@^4.1.2"
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.13",
+                      "from": "iconv-lite@^0.4.5"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@^0.5.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8"
+                        }
+                      }
+                    },
+                    "q": {
+                      "version": "1.4.1",
+                      "from": "q@^1.1.2"
+                    }
+                  }
+                },
+                "defs": {
+                  "version": "1.1.1",
+                  "from": "defs@~1.1.0",
+                  "dependencies": {
+                    "alter": {
+                      "version": "0.2.0",
+                      "from": "alter@~0.2.0",
+                      "dependencies": {
+                        "stable": {
+                          "version": "0.1.5",
+                          "from": "stable@~0.1.3"
+                        }
+                      }
+                    },
+                    "ast-traverse": {
+                      "version": "0.1.1",
+                      "from": "ast-traverse@~0.1.1"
+                    },
+                    "breakable": {
+                      "version": "1.0.0",
+                      "from": "breakable@~1.0.0"
+                    },
+                    "simple-fmt": {
+                      "version": "0.1.0",
+                      "from": "simple-fmt@~0.1.0"
+                    },
+                    "simple-is": {
+                      "version": "0.2.0",
+                      "from": "simple-is@~0.2.0"
+                    },
+                    "stringmap": {
+                      "version": "0.2.2",
+                      "from": "stringmap@~0.2.2"
+                    },
+                    "stringset": {
+                      "version": "0.2.1",
+                      "from": "stringset@~0.2.1"
+                    },
+                    "tryor": {
+                      "version": "0.1.2",
+                      "from": "tryor@~0.1.2"
+                    },
+                    "yargs": {
+                      "version": "3.27.0",
+                      "from": "yargs@~3.27.0",
+                      "dependencies": {
+                        "camelcase": {
+                          "version": "1.2.1",
+                          "from": "camelcase@^1.2.1"
+                        },
+                        "cliui": {
+                          "version": "2.1.0",
+                          "from": "cliui@^2.1.0",
+                          "dependencies": {
+                            "center-align": {
+                              "version": "0.1.2",
+                              "from": "center-align@^0.1.1",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@^0.1.0",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@^2.0.0",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.1",
+                                          "from": "is-buffer@^1.0.2"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@^1.0.1"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@^1.5.2"
+                                    }
+                                  }
+                                },
+                                "lazy-cache": {
+                                  "version": "0.2.7",
+                                  "from": "lazy-cache@^0.2.4"
+                                }
+                              }
+                            },
+                            "right-align": {
+                              "version": "0.1.3",
+                              "from": "right-align@^0.1.1",
+                              "dependencies": {
+                                "align-text": {
+                                  "version": "0.1.3",
+                                  "from": "align-text@^0.1.0",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "2.0.1",
+                                      "from": "kind-of@^2.0.0",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.1",
+                                          "from": "is-buffer@^1.0.2"
+                                        }
+                                      }
+                                    },
+                                    "longest": {
+                                      "version": "1.0.1",
+                                      "from": "longest@^1.0.1"
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.5.2",
+                                      "from": "repeat-string@^1.5.2"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "wordwrap": {
+                              "version": "0.0.2",
+                              "from": "wordwrap@0.0.2"
+                            }
+                          }
+                        },
+                        "decamelize": {
+                          "version": "1.1.2",
+                          "from": "decamelize@^1.0.0",
+                          "dependencies": {
+                            "escape-string-regexp": {
+                              "version": "1.0.4",
+                              "from": "escape-string-regexp@^1.0.4"
+                            }
+                          }
+                        },
+                        "os-locale": {
+                          "version": "1.4.0",
+                          "from": "os-locale@^1.4.0",
+                          "dependencies": {
+                            "lcid": {
+                              "version": "1.0.0",
+                              "from": "lcid@^1.0.0",
+                              "dependencies": {
+                                "invert-kv": {
+                                  "version": "1.0.0",
+                                  "from": "invert-kv@^1.0.0"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "window-size": {
+                          "version": "0.1.4",
+                          "from": "window-size@^0.1.2"
+                        },
+                        "y18n": {
+                          "version": "3.2.0",
+                          "from": "y18n@^3.2.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "esprima-fb": {
+                  "version": "15001.1001.0-dev-harmony-fb",
+                  "from": "esprima-fb@~15001.1001.0-dev-harmony-fb"
+                },
+                "recast": {
+                  "version": "0.10.33",
+                  "from": "recast@0.10.33",
+                  "dependencies": {
+                    "ast-types": {
+                      "version": "0.8.12",
+                      "from": "ast-types@0.8.12"
+                    }
+                  }
+                },
+                "through": {
+                  "version": "2.3.8",
+                  "from": "through@~2.3.8"
+                }
+              }
+            },
+            "regexpu": {
+              "version": "1.3.0",
+              "from": "regexpu@^1.3.0",
+              "dependencies": {
+                "esprima": {
+                  "version": "2.7.1",
+                  "from": "esprima@^2.6.0"
+                },
+                "recast": {
+                  "version": "0.10.43",
+                  "from": "recast@^0.10.10",
+                  "dependencies": {
+                    "esprima-fb": {
+                      "version": "15001.1001.0-dev-harmony-fb",
+                      "from": "esprima-fb@~15001.1001.0-dev-harmony-fb"
+                    },
+                    "ast-types": {
+                      "version": "0.8.15",
+                      "from": "ast-types@0.8.15"
+                    }
+                  }
+                },
+                "regenerate": {
+                  "version": "1.2.1",
+                  "from": "regenerate@^1.2.1"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@^0.2.0"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@^0.1.4",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@~0.5.0"
+                    }
+                  }
+                }
+              }
+            },
+            "repeating": {
+              "version": "1.1.3",
+              "from": "repeating@^1.1.2",
+              "dependencies": {
+                "is-finite": {
+                  "version": "1.0.1",
+                  "from": "is-finite@^1.0.0",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@^1.0.0"
+                    }
+                  }
+                }
+              }
+            },
+            "resolve": {
+              "version": "1.1.6",
+              "from": "resolve@^1.1.6"
+            },
+            "shebang-regex": {
+              "version": "1.0.0",
+              "from": "shebang-regex@^1.0.0"
+            },
+            "slash": {
+              "version": "1.0.0",
+              "from": "slash@^1.0.0"
+            },
+            "source-map": {
+              "version": "0.5.3",
+              "from": "source-map@^0.5.0"
+            },
+            "source-map-support": {
+              "version": "0.2.10",
+              "from": "source-map-support@^0.2.10",
+              "dependencies": {
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.0",
+                      "from": "amdefine@>=0.0.4"
+                    }
+                  }
+                }
+              }
+            },
+            "to-fast-properties": {
+              "version": "1.0.1",
+              "from": "to-fast-properties@^1.0.0"
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "from": "trim-right@^1.0.0"
+            },
+            "try-resolve": {
+              "version": "1.0.1",
+              "from": "try-resolve@^1.0.0"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The diffs being generated by our various permutations of babel dependencies are getting a little tough to follow. Running [npm shrinkwrap](https://docs.npmjs.com/cli/shrinkwrap) generates a file that should keep us all in sync. I imagine we'll all want to reinstall our modules if we decide to merge this. What do you guys think?
