### PR TITLE
Unbind existing resize events after resize [re #4700]

### DIFF
--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -98,7 +98,11 @@ class Chart extends Events {
         this._aggregateDataRange.on('change', (e) => this.throttledUpdate());
 
         if (this.resizeWidth || this.resizeHeight) {
-            this.resizeEventID = Utils.createUniqueId('resize.chart');
+            if (this.resizeEventID) {
+                d3.select(window).on(this.resizeEventID, null);
+            } else {
+                this.resizeEventID = Utils.createUniqueId('resize.chart');
+            }
             this.throttledResize = this.throttledResize || Utils.throttle(this.onWindowResize, 100);
             d3.select(window).on(this.resizeEventID, () => {
                 this.throttledResize(selectorOrEl);

--- a/lib/views/Histogram.js
+++ b/lib/views/Histogram.js
@@ -18,7 +18,10 @@ class Histogram extends Graph {
 
         bars.attr('y', d => this.yRange(d.y))
             .attr('x', d => this.xRange(d.x_low))
-            .attr('width', d => this.xRange(d.x_high) - this.xRange(d.x_low))
+            .attr('width', d => {
+                var width = this.xRange(d.x_high) - this.xRange(d.x_low);
+                return Math.max(width, 0);
+            })
             .attr('height', d => {
                 var yMin = Math.max(this.yRange.domain()[0], 0);
                 var height =  this.yRange(yMin) - this.yRange(d.y);


### PR DESCRIPTION
Title says it all. This prevents a nasty lil' event pileup.
