### PR TITLE
Keep zoom fixed while user is zoomed in [re #5802]

### DIFF
--- a/example/data_updating.html
+++ b/example/data_updating.html
@@ -37,36 +37,41 @@
 
         var lineGraph = new Nugget.LineGraph({
             color: '#09f',
-            dataSeries: dataSeries
+            dataSeries: dataSeries,
+            shouldAnimate: true
         });
         chart.add(lineGraph);
 
         var scatterGraph = new Nugget.ScatterGraph({
             color: '#009',
-            dataSeries: dataSeries
+            dataSeries: dataSeries,
+            shouldAnimate: true
         });
         chart.add(scatterGraph);
 
-        chart.appendTo('#container');
 
-        dataSeries.setData([
-            {x_value: 0,  y_value: 0},
-            {x_value: 10, y_value: 10},
-            {x_value: 20, y_value: 20},
-            {x_value: 30, y_value: 10},
-            {x_value: 40, y_value: 30}
-        ]);
+        var data = [];
+        for (var i = 0; i < 100; i++) {
+            data[i] = {
+                x_value: i,
+                y_value: 100 - (Math.random() * 100)
+            };
+        }
+
+        dataSeries.setData(data);
+
+        chart.appendTo('#container');
 
         setInterval(function() {
             var data = dataSeries.getDataCopy();
             var newData = data.map(function(d) {
                 return {
-                    x_value: Math.random() * 1000,
-                    y_value: Math.random() * 1000
+                    x_value: d.x_value,
+                    y_value: 100 - (Math.random() * 100)
                 }
             });
             dataSeries.setData(newData);
-        }, 1000);
+        }, 5000);
     });
 </script>
 </body>

--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -62,6 +62,9 @@ class Chart extends Events {
         // Origin ticks are always rendered, so subtract 1 from specified value
         this.numXTicks     = (typeof options.numXTicks === 'number') ? (options.numXTicks - 1) : null;
         this.numYTicks     = (typeof options.numYTicks === 'number') ? (options.numYTicks - 1) : null;
+
+        // Keep track of zoom state
+        this.isZoomed = false;
     }
 
     appendTo(selectorOrEl) {
@@ -174,12 +177,7 @@ class Chart extends Events {
         this._updateRanges();
         this._drawAxes();
 
-        if (isInitUpdate) {
-            this._initZoom();
-        } else {
-            this.zoomX.x(this.xRange);
-            this.zoomY.y(this.yRange);
-        }
+        this._updateZoom(isInitUpdate);
 
         this._childElementMap.forEach(function(nuggetView) {
             nuggetView.drawElement(this._drawingSurface, this.xRange, this.yRange, this.axisLabels);
@@ -250,6 +248,8 @@ class Chart extends Events {
     }
 
     _updateRanges() {
+        if (this.isZoomed) { return false; }
+
         var xScreenRange = [this.margins.left, (this.width - this.margins.right)];
         var yScreenRange = [(this.height - this.margins.bottom), this.margins.top];
         var scales = this.createScales(xScreenRange, yScreenRange);
@@ -285,6 +285,8 @@ class Chart extends Events {
     */
 
     _drawAxes() {
+        if (this.isZoomed) { return false; }
+
         if (this.shouldPadAxes) {
             this._padAxes(this.xRange, this.yRange);
         }
@@ -484,56 +486,40 @@ class Chart extends Events {
     * interaction functions
     */
 
-    _initZoom() {
-        var opts = {
-            d3Svg             : this.d3Svg,
-            drawingSurface    : this._drawingSurface,
-            children          : this._childElementMap,
-            xRange            : this.xRange,
-            yRange            : this.yRange,
-            xAxis             : this._xAxis,
-            yAxis             : this._yAxis,
-            margins           : this.margins,
-            width             : this.width,
-            height            : this.height,
-            showXGrid         : this.xGrid,
-            showYGrid         : this.yGrid,
-            dataSeriesType    : this._aggregateDataRange.getXAxisType()
-        };
+    _updateZoom(isInitUpdate) {
+        var opts = {};
         var scaleExtent = [0.1, 5000000];
+        var self = this;
 
-        opts.zoomFixtureX = opts.d3Svg.append('g')
-            .attr('class', 'zoom_fixture_x');
-        this.zoomX = d3.behavior.zoom()
-            .x(this.xRange)
-            .scaleExtent(scaleExtent)
-            .on('zoom', function() {
-                this._zoom(opts);
-            }.bind(this));
-        opts.zoomFixtureX.call(this.zoomX);
+        function updateAxisZoom(axis, range) {
+            var fixtureKey = 'zoomFixture' + axis.toUpperCase();
+            var fixtureClass = 'zoom_fixture_' + axis;
+            var zoomKey = 'zoom' + axis.toUpperCase();
 
-        opts.zoomFixtureY = opts.d3Svg.append('g')
-            .attr('class', 'zoom_fixture_y');
-        this.zoomY = d3.behavior.zoom()
-            .y(this.yRange)
-            .scaleExtent(scaleExtent)
-            .on('zoom', function() {
-                this._zoom(opts);
-            }.bind(this));
-        opts.zoomFixtureY.call(this.zoomY);
+            if (isInitUpdate) {
+                opts[fixtureKey] = self.d3Svg.append('g').attr('class', fixtureClass);
+                self[zoomKey] = d3.behavior.zoom().on('zoom', self._zoom.bind(self, opts));
+            } else {
+                opts[fixtureKey] = self.d3Svg.select('.' + fixtureClass);
+            }
+
+            self[zoomKey][axis](range).scaleExtent(scaleExtent);
+            opts[fixtureKey].call(self[zoomKey]);
+        }
+
+        updateAxisZoom('x', this.xRange);
+        updateAxisZoom('y', this.yRange);
 
         this._listenForClicksOutsideOfChart(opts);
         this._waitForClickToEnableZooming(opts);
-
         this._initBoxZoom(opts);
-
         this._initZoomReset(opts);
     }
 
     _listenForClicksOutsideOfChart(opts) {
         // Zooming is disabled if the user clicks outside of the Chart. We use native javascript
         // event methods here because we need to stop propagation when the Chart is clicked.
-        var d3SvgNode = opts.d3Svg.node();
+        var d3SvgNode = this.d3Svg.node();
         d3SvgNode.addEventListener('click', function(e) {
             e.stopPropagation();
         });
@@ -552,28 +538,28 @@ class Chart extends Events {
             return;
         }
 
-            // Wait for a mouse click before enabling zooming
-        opts.d3Svg.on('mouseup.enable_zooming', () => {
+        // Wait for a mouse click before enabling zooming
+        this.d3Svg.on('mouseup.enable_zooming', () => {
             this._enableZooming(opts);
-            opts.d3Svg.on('mouseup.enable_zooming', null);
+            this.d3Svg.on('mouseup.enable_zooming', null);
         });
     }
 
     _enableZooming(opts) {
-        var dataSeriesType = opts.dataSeriesType;
+        var dataSeriesType = this._aggregateDataRange.getXAxisType();
 
         // proxy through mouse zoom events to x and y axis zoom behaviors
         if (dataSeriesType !== 'ordinal') {
-            opts.d3Svg.on('touchstart.zoom.x', opts.zoomFixtureX.on('touchstart.zoom'));
-            opts.d3Svg.on('wheel.zoom.x', opts.zoomFixtureX.on('wheel.zoom'));
-            opts.d3Svg.on('mousewheel.zoom.x', opts.zoomFixtureX.on('mousewheel.zoom'));
-            opts.d3Svg.on('MozMousePixelScroll.zoom.x', opts.zoomFixtureX.on('MozMousePixelScroll.zoom'));
+            this.d3Svg.on('touchstart.zoom.x', opts.zoomFixtureX.on('touchstart.zoom'));
+            this.d3Svg.on('wheel.zoom.x', opts.zoomFixtureX.on('wheel.zoom'));
+            this.d3Svg.on('mousewheel.zoom.x', opts.zoomFixtureX.on('mousewheel.zoom'));
+            this.d3Svg.on('MozMousePixelScroll.zoom.x', opts.zoomFixtureX.on('MozMousePixelScroll.zoom'));
         }
 
-        opts.d3Svg.on('touchstart.zoom.y', opts.zoomFixtureY.on('touchstart.zoom'));
-        opts.d3Svg.on('wheel.zoom.y', opts.zoomFixtureY.on('wheel.zoom'));
-        opts.d3Svg.on('mousewheel.zoom.y', opts.zoomFixtureY.on('mousewheel.zoom'));
-        opts.d3Svg.on('MozMousePixelScroll.zoom.y', opts.zoomFixtureY.on('MozMousePixelScroll.zoom'));
+        this.d3Svg.on('touchstart.zoom.y', opts.zoomFixtureY.on('touchstart.zoom'));
+        this.d3Svg.on('wheel.zoom.y', opts.zoomFixtureY.on('wheel.zoom'));
+        this.d3Svg.on('mousewheel.zoom.y', opts.zoomFixtureY.on('mousewheel.zoom'));
+        this.d3Svg.on('MozMousePixelScroll.zoom.y', opts.zoomFixtureY.on('MozMousePixelScroll.zoom'));
     }
 
     _disableZooming(opts) {
@@ -582,21 +568,23 @@ class Chart extends Events {
             'touchstart.zoom.y', 'wheel.zoom.y', 'mousewheel.zoom.y', 'MozMousePixelScroll.zoom.y'
         ];
         zoomEvents.forEach(function(evt) {
-            opts.d3Svg.on(evt, null);
+            this.d3Svg.on(evt, null);
         }, this);
     }
 
     _zoom(opts) {
-        var xAxisEl = opts.d3Svg.select('.x_axis').call(this._xAxis);
-        var yAxisEl = opts.d3Svg.select('.y_axis').call(this._yAxis);
+        var xAxisEl = this.d3Svg.select('.x_axis').call(this._xAxis);
+        var yAxisEl = this.d3Svg.select('.y_axis').call(this._yAxis);
 
-        this._styleAxis(xAxisEl, opts.showXGrid);
-        this._styleAxis(yAxisEl, opts.showYGrid);
+        this._styleAxis(xAxisEl, this.showXGrid);
+        this._styleAxis(yAxisEl, this.showYGrid);
 
-        opts.children.forEach(function(view, id, map) {
+        this._childElementMap.forEach(function(view, id, map) {
             // don't animate on regular zoom, since zoom already animates
-            view.drawElement(opts.drawingSurface, this.xRange, this.yRange, this.axisLabels, false);
+            view.drawElement(this._drawingSurface, this.xRange, this.yRange, this.axisLabels, false);
         }, this);
+
+        this.isZoomed = true;
     }
 
     _initZoomReset(opts) {
@@ -605,32 +593,36 @@ class Chart extends Events {
         // standard "dblclick" event doesn't work when boxZoom is enabled so we simulate with "mousedown"
         var lastClickTime = 0;
         var self = this;
-        opts.d3Svg.on('mousedown.zoom', function() {
+        this.d3Svg.on('mousedown.zoom', function() {
             var clickTime = new Date().getTime();
             if (clickTime - lastClickTime < DOUBLE_CLICK_MS) {
                 var translate = [0, 0];
                 var scale = 1;
                 var duration = 250;
 
-                if (opts.dataSeriesType !== 'ordinal') {
+                if (self._aggregateDataRange.getXAxisType() !== 'ordinal') {
                     self.zoomX.translate(translate);
                     self.zoomX.scale(scale);
                     self.zoomX.event(opts.zoomFixtureX.transition().duration(duration));
                 }
+
+                self.zoomY.on('zoomend.updateZoomState', function() {
+                    self.isZoomed = false;
+                    self.zoomY.on('zoomend.updateZoomState', null);
+                    self.update();
+                    self.trigger('zoomreset');
+                });
 
                 self.zoomY.translate(translate);
                 self.zoomY.scale(scale);
                 self.zoomY.event(opts.zoomFixtureY.transition().duration(duration));
 
                 // Disable zoom on double click
-                opts.d3Svg.on('mouseup.waitForDblClickToFinish', function() {
-                    opts.d3Svg.on('mouseup.waitForDblClickToFinish', null);
+                self.d3Svg.on('mouseup.waitForDblClickToFinish', function() {
+                    self.d3Svg.on('mouseup.waitForDblClickToFinish', null);
                     this._disableZooming(opts);
                     this._waitForClickToEnableZooming(opts);
                 }.bind(this));
-
-                // trigger event on chart to indicate that zoom has been reset
-                self.trigger('zoomreset');
             }
             lastClickTime = clickTime;
         }.bind(this));
@@ -640,7 +632,7 @@ class Chart extends Events {
         if (!this.boxZoom) {
             return;
         }
-        var d3Svg = opts.d3Svg;
+        var d3Svg = this.d3Svg;
 
         // save original x and y ranges
         var origXRange = this.xRange.copy();
@@ -658,10 +650,10 @@ class Chart extends Events {
             var startY = coords[1];
 
             var bounds = {
-                left   : opts.margins.left,
-                right  : opts.width - opts.margins.right,
-                top    : opts.margins.top,
-                bottom : opts.height - opts.margins.bottom
+                left   : self.margins.left,
+                right  : self.width - self.margins.right,
+                top    : self.margins.top,
+                bottom : self.height - self.margins.bottom
             };
 
             // Keep starting position within graph bounds
@@ -737,20 +729,20 @@ class Chart extends Events {
                 var boxTop = Math.min(startY, endY);
                 var boxBottom = Math.max(startY, endY);
 
-                var screenLeft = opts.margins.left;
-                var screenRight = opts.width - opts.margins.right;
-                var screenTop = opts.margins.top;
-                var screenBottom = opts.height - opts.margins.bottom;
+                var screenLeft = self.margins.left;
+                var screenRight = self.width - self.margins.right;
+                var screenTop = self.margins.top;
+                var screenBottom = self.height - self.margins.bottom;
 
                 var dataXLow, dataXHigh, scaleX, translateX = 0;
                 if (!isOrdinal) {
-                    dataXLow = opts.xRange.invert(boxLeft);
-                    dataXHigh = opts.xRange.invert(boxRight);
+                    dataXLow = self.xRange.invert(boxLeft);
+                    dataXHigh = self.xRange.invert(boxRight);
                     scaleX = (screenRight - screenLeft) / (origXRange(dataXHigh) - origXRange(dataXLow));
                     translateX = screenLeft - scaleX * origXRange(dataXLow);
                 }
-                var dataYLow = opts.yRange.invert(boxBottom);
-                var dataYHigh = opts.yRange.invert(boxTop);
+                var dataYLow = self.yRange.invert(boxBottom);
+                var dataYHigh = self.yRange.invert(boxTop);
                 var scaleY = (screenBottom - screenTop) / (origYRange(dataYLow) - origYRange(dataYHigh));
                 var translateY = screenTop - scaleY * origYRange(dataYHigh);
 

--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -418,6 +418,31 @@ function (
                 expect(getDomains()).toEqual(origDomains);
             });
 
+            it('shouldn\'t update ranges and axes while zoomed', function(done) {
+                expect(chart.isZoomed).toBe(false);
+
+                Utils.trigger(container, 'mousedown', 50, 50);
+                Utils.trigger(container, 'mousemove', 200, 200);
+                Utils.trigger(container, 'mouseup');
+
+                chart.zoomX.on('zoomend.testZoomIn', function() {
+                    chart.zoomX.on('zoomend.testZoomIn', null);
+                    expect(chart.isZoomed).toBe(true);
+                    expect(chart._drawAxes()).toBe(false);
+                    expect(chart._updateRanges()).toBe(false);
+
+                    // This triggers the zoom reset
+                    Utils.trigger(container, 'mousedown');
+                });
+
+                chart.on('zoomreset', function() {
+                    expect(chart.isZoomed).toBe(false);
+                    expect(chart._drawAxes()).not.toBe(false);
+                    expect(chart._updateRanges()).not.toBe(false);
+                    done();
+                });
+            });
+
             describe('Dragging', function() {
                 function testDrag(opts) {
                     Utils.trigger(container, 'mousedown', opts.x1, opts.y1);


### PR DESCRIPTION
This prevents ranges/axes from being updated while the user is zoomed in on a plot. As a result, the plot doesn't jump around like crazy if the user is zoomed and the data is updated.
