### PR TITLE
Fix test failure on sauce labs

### DIFF
--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -431,7 +431,8 @@ function (
                     expect(chart._drawAxes()).toBe(false);
                     expect(chart._updateRanges()).toBe(false);
 
-                    // This triggers the zoom reset
+                    // This triggers the zoom reset (saucelabs requires two mousedown events here)
+                    Utils.trigger(container, 'mousedown');
                     Utils.trigger(container, 'mousedown');
                 });
 


### PR DESCRIPTION
Chrome on Sauce Labs needed an extra `mousedown` event to be triggered to make the chart in this test zoom out. Go figure :smile:

Merging right away to get things back in the green ✅ 
