### PR TITLE
More efficiently validate NumericalDataSeries

### DIFF
--- a/lib/models/NumericalDataSeries.js
+++ b/lib/models/NumericalDataSeries.js
@@ -1,5 +1,7 @@
 import DataSeries from './DataSeries';
 
+const NUMERIC_KEYS = ['x_min', 'x_value', 'x_max', 'y_min', 'y_value', 'y_max'];
+
 class NumericalDataSeries extends DataSeries {
     constructor(data, options) {
         /*
@@ -71,36 +73,16 @@ class NumericalDataSeries extends DataSeries {
     }
 
     _validate(data) {
-        var isValid = data.every(function(point) {
+        const firstPointKeys = (data.length) ? Object.keys(data[0]) : [];
+        return data.every(point => (
             // each point needs to be an object
-            if (typeof point !== 'object') {
-                return false;
-            }
-            // make sure the relevant axis keys are numeric
-            var numericKeys = ['x_min', 'x_value', 'x_max', 'y_min', 'y_value', 'y_max'];
-            var hasAllNumbers = numericKeys.every(key => {
-                // make sure the key is either not present, or if present, is a number
-                return (point[key] === undefined) || (typeof point[key] === 'number');
-            });
-            if (!hasAllNumbers) {
-                return false;
-            }
-            // make sure all points have the same data structure
-            for (let i=0; i < data.length - 1; i++) {
-                let keys1 = Object.keys(data[i]);
-                let keys2 = Object.keys(data[i+1]);
-                let keys1Set = new Set(keys1);
-                let keys2Set = new Set(keys2);
-
-                if (!keys2.every(key => keys1Set.has(key)) ||
-                    !keys1.every(key => keys2Set.has(key))) {
-                    return false;
-                }
-
-            }
-            return true;
-        });
-        return isValid;
+            (typeof point === 'object') &&
+            // make sure the relevant axis keys are numeric if present
+            NUMERIC_KEYS.every(key => ((point[key] === undefined) || (typeof point[key] === 'number'))) &&
+            // make sure all keys have the same data structure
+            (Object.keys(point).length === firstPointKeys.length) &&
+            firstPointKeys.every(key => (key in point))
+        ));
     }
 }
 


### PR DESCRIPTION
`_validate` currently loops through the entire data array in an `Array.prototype.every` callback, repeating the same work `data.length` times.