### PR TITLE
Don't reset ranges when a view is removed while zoomed [re #7036]

### DIFF
--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -72,7 +72,7 @@ class Chart extends Events {
             document.querySelectorAll(selectorOrEl)[0] : selectorOrEl;
 
         if (this.d3Svg) {
-            return element.parentNode.replaceChild(this.d3Svg.node(), element);
+            return this.resizeChart(selectorOrEl, true);
         }
 
         var defaultDimensions = this._getDefaultDimensions(element);
@@ -106,7 +106,7 @@ class Chart extends Events {
             } else {
                 this.resizeEventID = Utils.createUniqueId('resize.chart');
             }
-            this.throttledResize = this.throttledResize || Utils.throttle(this.onWindowResize, 100);
+            this.throttledResize = this.throttledResize || Utils.throttle(this.resizeChart, 100);
             d3.select(window).on(this.resizeEventID, () => {
                 this.throttledResize(selectorOrEl);
             });
@@ -199,11 +199,13 @@ class Chart extends Events {
         this.d3Svg.select('.y_axis').call(this._yAxis);
     }
 
-    onWindowResize(selectorOrEl) {
-        Utils.emptyNode( this.d3Svg.node() );
+    resizeChart(selectorOrEl, forceResize) {
+        if (this.d3Svg) {
+            Utils.emptyNode( this.d3Svg.node() );
+        }
 
-        if (this.resizeWidth)  { delete this.width;  }
-        if (this.resizeHeight) { delete this.height; }
+        if (this.resizeWidth || forceResize)  { delete this.width;  }
+        if (this.resizeHeight || forceResize) { delete this.height; }
 
         delete this.d3Svg;
         delete this.xRange;

--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -117,7 +117,6 @@ class Chart extends Events {
         if (!this._checkInstance(nuggetView)) {
             throw 'Must be a valid Nugget View type';
         }
-
         this._childElementMap.set(nuggetView.id, nuggetView);
         if (nuggetView.dataSeries) {
             this._aggregateDataRange.addDataSeries(nuggetView.dataSeries);
@@ -165,12 +164,14 @@ class Chart extends Events {
         var aggregateDataRange = this._aggregateDataRange;
         aggregateDataRange.removeDataSeries(nuggetView.dataSeries);
 
-        this._childElementMap.delete(nuggetView.id);
         nuggetView.remove();
+        this._childElementMap.delete(nuggetView.id);
 
-        var scales  = aggregateDataRange.getScales(xScreenRange, yScreenRange);
-        this.xRange = scales.x;
-        this.yRange = scales.y;
+        if (!this.isZoomed) {
+            var scales  = aggregateDataRange.getScales(xScreenRange, yScreenRange);
+            this.xRange = scales.x;
+            this.yRange = scales.y;
+        }
     }
 
     update(isInitUpdate) {

--- a/lib/views/Graph.js
+++ b/lib/views/Graph.js
@@ -49,8 +49,10 @@ class Graph extends GuideLayer {
     }
 
     remove() {
-        this.d3Svg.remove();
-        delete this.d3Svg;
+        if (this.d3Svg) {
+            this.d3Svg.remove();
+            delete this.d3Svg;
+        }
     }
 
     draw() {

--- a/test/helpers/utils.js
+++ b/test/helpers/utils.js
@@ -36,6 +36,12 @@ window.Utils = {
 
     getPointsFromPath: function(pathData) {
         return pathData.split(/[,ML]/).map(Number);
+    },
+
+    zoomToRegion: function(chartEl, coords) {
+        Utils.trigger(chartEl, 'mousedown', coords.x1, coords.y1);
+        Utils.trigger(chartEl, 'mousemove', coords.x2, coords.y2);
+        Utils.trigger(chartEl, 'mouseup');
     }
 };
 

--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -36,16 +36,27 @@ function (
             $svg.remove();
         });
 
-        it('should reuse it\'s d3Svg on subsequent appendTo calls', function() {
-            var chart = new Nugget.Chart();
-            chart.add(line);
-            expect(chart.d3Svg).toBeFalsy();
+        it('should force a resize on subsequent appendTo calls', function() {
+            var chart = new Nugget.Chart({
+                width: 500,
+                height: 200
+            });
+            spyOn(chart, 'resizeChart').and.callThrough();
 
+            chart.add(line);
             chart.appendTo('#container');
+            expect(chart.width).toBe(500);
+            expect(chart.height).toBe(200);
+
             var d3Svg = chart.d3Svg;
 
             chart.appendTo('#container');
-            expect(d3Svg).toBe(chart.d3Svg);
+
+            expect(chart.width).toBe($('body').width());
+            expect(chart.height).toBe(277);
+
+            expect(chart.resizeChart).toHaveBeenCalledWith('#container', true);
+            expect(d3Svg).not.toBe(chart.d3Svg);
         });
 
         it('should remove a child element and then reset itself', function() {

--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -405,9 +405,7 @@ function (
                 expect(origDomains.x[0]).toBeCloseTo(-0.63, 2);
                 expect(origDomains.y[1]).toBeCloseTo(102.22, 2);
 
-                Utils.trigger(container, 'mousedown', 50, 50);
-                Utils.trigger(container, 'mousemove', 100, 100);
-                Utils.trigger(container, 'mouseup');
+                Utils.zoomToRegion(container, { x1: 50, y1: 50, x2: 100, y2: 100 });
 
                 var newDomains = getDomains();
                 expect(newDomains.x[0]).toBeCloseTo(-0.63, 2);
@@ -419,9 +417,7 @@ function (
             it('should reset zoom on doubleclick', function() {
                 var origDomains = getDomains();
 
-                Utils.trigger(container, 'mousedown', 50, 50);
-                Utils.trigger(container, 'mousemove', 200, 200);
-                Utils.trigger(container, 'mouseup');
+                Utils.zoomToRegion(container, { x1: 50, y1: 50, x2: 200, y2: 200 });
 
                 expect(getDomains()).not.toEqual(origDomains);
 
@@ -434,9 +430,7 @@ function (
             it('shouldn\'t update ranges and axes while zoomed', function(done) {
                 expect(chart.isZoomed).toBe(false);
 
-                Utils.trigger(container, 'mousedown', 50, 50);
-                Utils.trigger(container, 'mousemove', 200, 200);
-                Utils.trigger(container, 'mouseup');
+                Utils.zoomToRegion(container, { x1: 50, y1: 50, x2: 200, y2: 200 });
 
                 chart.zoomX.on('zoomend.testZoomIn', function() {
                     chart.zoomX.on('zoomend.testZoomIn', null);
@@ -453,6 +447,22 @@ function (
                     expect(chart.isZoomed).toBe(false);
                     expect(chart._drawAxes()).not.toBe(false);
                     expect(chart._updateRanges()).not.toBe(false);
+                    done();
+                });
+            });
+
+            it('shouldn\'t update ranges on graph removal if the user is zoomed in', function(done) {
+                Utils.zoomToRegion(container, { x1: 50, y1: 50, x2: 200, y2: 200 });
+
+                chart.zoomX.on('zoomend.testZoomIn', function() {
+                    chart.zoomX.on('zoomend.testZoomIn', null);
+
+                    var preRemovalDomains = getDomains();
+                    chart.remove(line);
+
+                    var postRemovalDomains = getDomains();
+                    expect(preRemovalDomains).toEqual(postRemovalDomains);
+
                     done();
                 });
             });


### PR DESCRIPTION
This ensures that the Chart stays at the current zoom level when Graph views are removed from it. Previously, removing an item would cause the zoom level to reset to the default (no zoom).