### PR TITLE
Revert appendTo resize changes [re #8000]

### DIFF
--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -106,7 +106,7 @@ class Chart extends Events {
             } else {
                 this.resizeEventID = Utils.createUniqueId('resize.chart');
             }
-            this.throttledResize = this.throttledResize || Utils.throttle(this.onWindowResize, 100);
+            this.throttledResize = this.throttledResize || Utils.throttle(this.resize, 100);
             d3.select(window).on(this.resizeEventID, () => {
                 this.throttledResize(selectorOrEl);
             });
@@ -199,7 +199,7 @@ class Chart extends Events {
         this.d3Svg.select('.y_axis').call(this._yAxis);
     }
 
-    onWindowResize(selectorOrEl) {
+    resize(selectorOrEl) {
         Utils.emptyNode( this.d3Svg.node() );
 
         if (this.resizeWidth)  { delete this.width;  }

--- a/lib/presenter/Chart.js
+++ b/lib/presenter/Chart.js
@@ -72,7 +72,7 @@ class Chart extends Events {
             document.querySelectorAll(selectorOrEl)[0] : selectorOrEl;
 
         if (this.d3Svg) {
-            return this.resizeChart(selectorOrEl, true);
+            return element.parentNode.replaceChild(this.d3Svg.node(), element);
         }
 
         var defaultDimensions = this._getDefaultDimensions(element);
@@ -106,7 +106,7 @@ class Chart extends Events {
             } else {
                 this.resizeEventID = Utils.createUniqueId('resize.chart');
             }
-            this.throttledResize = this.throttledResize || Utils.throttle(this.resizeChart, 100);
+            this.throttledResize = this.throttledResize || Utils.throttle(this.onWindowResize, 100);
             d3.select(window).on(this.resizeEventID, () => {
                 this.throttledResize(selectorOrEl);
             });
@@ -199,13 +199,11 @@ class Chart extends Events {
         this.d3Svg.select('.y_axis').call(this._yAxis);
     }
 
-    resizeChart(selectorOrEl, forceResize) {
-        if (this.d3Svg) {
-            Utils.emptyNode( this.d3Svg.node() );
-        }
+    onWindowResize(selectorOrEl) {
+        Utils.emptyNode( this.d3Svg.node() );
 
-        if (this.resizeWidth || forceResize)  { delete this.width;  }
-        if (this.resizeHeight || forceResize) { delete this.height; }
+        if (this.resizeWidth)  { delete this.width;  }
+        if (this.resizeHeight) { delete this.height; }
 
         delete this.d3Svg;
         delete this.xRange;

--- a/test/presenter/Chart.spec.js
+++ b/test/presenter/Chart.spec.js
@@ -36,27 +36,16 @@ function (
             $svg.remove();
         });
 
-        it('should force a resize on subsequent appendTo calls', function() {
-            var chart = new Nugget.Chart({
-                width: 500,
-                height: 200
-            });
-            spyOn(chart, 'resizeChart').and.callThrough();
-
+        it('should reuse it\'s d3Svg on subsequent appendTo calls', function() {
+            var chart = new Nugget.Chart();
             chart.add(line);
-            chart.appendTo('#container');
-            expect(chart.width).toBe(500);
-            expect(chart.height).toBe(200);
+            expect(chart.d3Svg).toBeFalsy();
 
+            chart.appendTo('#container');
             var d3Svg = chart.d3Svg;
 
             chart.appendTo('#container');
-
-            expect(chart.width).toBe($('body').width());
-            expect(chart.height).toBe(277);
-
-            expect(chart.resizeChart).toHaveBeenCalledWith('#container', true);
-            expect(d3Svg).not.toBe(chart.d3Svg);
+            expect(d3Svg).toBe(chart.d3Svg);
         });
 
         it('should remove a child element and then reset itself', function() {


### PR DESCRIPTION
This reverts the resizing changes I added in an attempt to fix our zero-width sizing issues. Turns out that they break some zooming functionality in the main app code.

There is one change here: `resizeChart` (previously `onWindowResize`) is now just called `resize`. That seems to make more sense as a public method of `Chart`.