### PR TITLE
Upgrade build dependencies (babel, almond)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -25,8 +25,12 @@ module.exports = function(grunt) {
         babel: {
             options: {
                 sourceMap: true,
-                modules: 'amd',
-                blacklist: 'useStrict'
+                presets: [
+                    ['es2015', { modules: 'amd' }]
+                ],
+                plugins: [
+                    'add-module-exports'
+                ]
             },
             dist: {
                 files: [{
@@ -137,7 +141,7 @@ module.exports = function(grunt) {
 
     grunt.registerTask('addPolyfill', function() {
         var fs = require('fs');
-        var polyfillPath = './node_modules/grunt-babel/node_modules/babel-core/browser-polyfill.js';
+        var polyfillPath = './node_modules/babel-polyfill/dist/polyfill.js';
         var polyfill = '\r' + fs.readFileSync(polyfillPath, {encoding: 'utf8'});
         fs.appendFileSync('./build/Nugget.js', polyfill, {encoding: 'utf8'});
     });

--- a/dependencies/almond.js
+++ b/dependencies/almond.js
@@ -1,11 +1,9 @@
 /**
- * @license almond 0.3.1 Copyright (c) 2011-2014, The Dojo Foundation All Rights Reserved.
- * Available via the MIT or new BSD license.
- * see: http://github.com/jrburke/almond for details
+ * @license almond 0.3.3 Copyright jQuery Foundation and other contributors.
+ * Released under MIT license, http://github.com/requirejs/almond/LICENSE
  */
 //Going sloppy to avoid 'use strict' string cost, but strict practices should
 //be followed.
-/*jslint sloppy: true */
 /*global setTimeout: false */
 
 var requirejs, require, define;
@@ -33,60 +31,58 @@ var requirejs, require, define;
      */
     function normalize(name, baseName) {
         var nameParts, nameSegment, mapValue, foundMap, lastIndex,
-            foundI, foundStarMap, starI, i, j, part,
+            foundI, foundStarMap, starI, i, j, part, normalizedBaseParts,
             baseParts = baseName && baseName.split("/"),
             map = config.map,
             starMap = (map && map['*']) || {};
 
         //Adjust any relative paths.
-        if (name && name.charAt(0) === ".") {
-            //If have a base name, try to normalize against it,
-            //otherwise, assume it is a top-level require that will
-            //be relative to baseUrl in the end.
-            if (baseName) {
-                name = name.split('/');
-                lastIndex = name.length - 1;
+        if (name) {
+            name = name.split('/');
+            lastIndex = name.length - 1;
 
-                // Node .js allowance:
-                if (config.nodeIdCompat && jsSuffixRegExp.test(name[lastIndex])) {
-                    name[lastIndex] = name[lastIndex].replace(jsSuffixRegExp, '');
-                }
+            // If wanting node ID compatibility, strip .js from end
+            // of IDs. Have to do this here, and not in nameToUrl
+            // because node allows either .js or non .js to map
+            // to same file.
+            if (config.nodeIdCompat && jsSuffixRegExp.test(name[lastIndex])) {
+                name[lastIndex] = name[lastIndex].replace(jsSuffixRegExp, '');
+            }
 
-                //Lop off the last part of baseParts, so that . matches the
-                //"directory" and not name of the baseName's module. For instance,
-                //baseName of "one/two/three", maps to "one/two/three.js", but we
-                //want the directory, "one/two" for this normalization.
-                name = baseParts.slice(0, baseParts.length - 1).concat(name);
+            // Starts with a '.' so need the baseName
+            if (name[0].charAt(0) === '.' && baseParts) {
+                //Convert baseName to array, and lop off the last part,
+                //so that . matches that 'directory' and not name of the baseName's
+                //module. For instance, baseName of 'one/two/three', maps to
+                //'one/two/three.js', but we want the directory, 'one/two' for
+                //this normalization.
+                normalizedBaseParts = baseParts.slice(0, baseParts.length - 1);
+                name = normalizedBaseParts.concat(name);
+            }
 
-                //start trimDots
-                for (i = 0; i < name.length; i += 1) {
-                    part = name[i];
-                    if (part === ".") {
-                        name.splice(i, 1);
-                        i -= 1;
-                    } else if (part === "..") {
-                        if (i === 1 && (name[2] === '..' || name[0] === '..')) {
-                            //End of the line. Keep at least one non-dot
-                            //path segment at the front so it can be mapped
-                            //correctly to disk. Otherwise, there is likely
-                            //no path mapping for a path starting with '..'.
-                            //This can still fail, but catches the most reasonable
-                            //uses of ..
-                            break;
-                        } else if (i > 0) {
-                            name.splice(i - 1, 2);
-                            i -= 2;
-                        }
+            //start trimDots
+            for (i = 0; i < name.length; i++) {
+                part = name[i];
+                if (part === '.') {
+                    name.splice(i, 1);
+                    i -= 1;
+                } else if (part === '..') {
+                    // If at the start, or previous value is still ..,
+                    // keep them so that when converted to a path it may
+                    // still work when converted to a path, even though
+                    // as an ID it is less than ideal. In larger point
+                    // releases, may be better to just kick out an error.
+                    if (i === 0 || (i === 1 && name[2] === '..') || name[i - 1] === '..') {
+                        continue;
+                    } else if (i > 0) {
+                        name.splice(i - 1, 2);
+                        i -= 2;
                     }
                 }
-                //end trimDots
-
-                name = name.join("/");
-            } else if (name.indexOf('./') === 0) {
-                // No baseName, so this is ID is resolved relative
-                // to baseUrl, pull off the leading dot.
-                name = name.substring(2);
             }
+            //end trimDots
+
+            name = name.join('/');
         }
 
         //Apply map config if available.
@@ -199,32 +195,39 @@ var requirejs, require, define;
         return [prefix, name];
     }
 
+    //Creates a parts array for a relName where first part is plugin ID,
+    //second part is resource ID. Assumes relName has already been normalized.
+    function makeRelParts(relName) {
+        return relName ? splitPrefix(relName) : [];
+    }
+
     /**
      * Makes a name map, normalizing the name, and using a plugin
      * for normalization if necessary. Grabs a ref to plugin
      * too, as an optimization.
      */
-    makeMap = function (name, relName) {
+    makeMap = function (name, relParts) {
         var plugin,
             parts = splitPrefix(name),
-            prefix = parts[0];
+            prefix = parts[0],
+            relResourceName = relParts[1];
 
         name = parts[1];
 
         if (prefix) {
-            prefix = normalize(prefix, relName);
+            prefix = normalize(prefix, relResourceName);
             plugin = callDep(prefix);
         }
 
         //Normalize according
         if (prefix) {
             if (plugin && plugin.normalize) {
-                name = plugin.normalize(name, makeNormalize(relName));
+                name = plugin.normalize(name, makeNormalize(relResourceName));
             } else {
-                name = normalize(name, relName);
+                name = normalize(name, relResourceName);
             }
         } else {
-            name = normalize(name, relName);
+            name = normalize(name, relResourceName);
             parts = splitPrefix(name);
             prefix = parts[0];
             name = parts[1];
@@ -271,13 +274,14 @@ var requirejs, require, define;
     };
 
     main = function (name, deps, callback, relName) {
-        var cjsModule, depName, ret, map, i,
+        var cjsModule, depName, ret, map, i, relParts,
             args = [],
             callbackType = typeof callback,
             usingExports;
 
         //Use name if no relName
         relName = relName || name;
+        relParts = makeRelParts(relName);
 
         //Call the callback to define the module, if necessary.
         if (callbackType === 'undefined' || callbackType === 'function') {
@@ -286,7 +290,7 @@ var requirejs, require, define;
             //Default to [require, exports, module] if no deps
             deps = !deps.length && callback.length ? ['require', 'exports', 'module'] : deps;
             for (i = 0; i < deps.length; i += 1) {
-                map = makeMap(deps[i], relName);
+                map = makeMap(deps[i], relParts);
                 depName = map.f;
 
                 //Fast path CommonJS standard dependencies.
@@ -342,7 +346,7 @@ var requirejs, require, define;
             //deps arg is the module name, and second arg (if passed)
             //is just the relName.
             //Normalize module name, if it contains . or ..
-            return callDep(makeMap(deps, callback).f);
+            return callDep(makeMap(deps, makeRelParts(callback)).f);
         } else if (!deps.splice) {
             //deps is a config object, not an array.
             config = deps;

--- a/lib/views/BinnedMeanGraph.js
+++ b/lib/views/BinnedMeanGraph.js
@@ -93,7 +93,7 @@ class BinnedMeanGraph extends Graph {
         var xMax = width - margins.right;
         var xLabelFormat = chartOpts.xLabelFormat;
 
-        function updateGuides(circleData, circleIdx) {
+        const updateGuides = (circleData, circleIdx) => {
             var data = [circleData];
 
             /**
@@ -170,7 +170,7 @@ class BinnedMeanGraph extends Graph {
             zoomY.on('zoom.binned_mean_guides', function() {
                 updateGuides.call(circleEl, circleData, circleIdx);
             });
-        }
+        };
 
         circles
             .on('mouseenter', updateGuides)

--- a/lib/views/BoxPlot.js
+++ b/lib/views/BoxPlot.js
@@ -92,6 +92,7 @@ class BoxPlot extends Graph {
         var yRange       = this.yRange;
         var zoomY        = chartOpts.zoomY;
         var getLabelBBox = super.getLabelBBox;
+        var boxPlot      = this;
 
         function updateGuides(boxData, boxIdx) {
             /*jshint validthis:true */
@@ -117,7 +118,7 @@ class BoxPlot extends Graph {
 
             guides.exit().remove();
 
-            super.drawYLineGuide(guides, g, chartOpts, {
+            boxPlot.drawYLineGuide(guides, g, chartOpts, {
                 onLineEnter: function(line) {
                     line
                         .attr('x1', function(d) {

--- a/lib/views/ScatterGraph.js
+++ b/lib/views/ScatterGraph.js
@@ -95,7 +95,7 @@ class ScatterGraph extends Graph {
         var zoomY   = chartOpts.zoomY;
         var color   = this.guideColor;
 
-        function updateGuides(circleData, circleIdx) {
+        const updateGuides = (circleData, circleIdx) => {
             var data = [circleData];
 
             var guides = container.selectAll('.scatter_plot_guides').data(data);
@@ -120,7 +120,7 @@ class ScatterGraph extends Graph {
             zoomY.on('zoom.scatter_plot_guides', function() {
                 updateGuides.call(circleEl, circleData, circleIdx);
             });
-        }
+        };
 
         circles
             .on('mouseenter', updateGuides)

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,6 +2,2250 @@
   "name": "Nugget",
   "version": "0.0.1",
   "dependencies": {
+    "babel-plugin-add-module-exports": {
+      "version": "0.2.1",
+      "from": "babel-plugin-add-module-exports@0.2.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz"
+    },
+    "babel-polyfill": {
+      "version": "6.22.0",
+      "from": "babel-polyfill@",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.22.0.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "2.4.1",
+          "from": "core-js@^2.4.0"
+        },
+        "babel-runtime": {
+          "version": "6.22.0",
+          "from": "babel-runtime@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.1",
+          "from": "regenerator-runtime@^0.10.0"
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.22.0",
+      "from": "babel-preset-es2015@6.22.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.22.0.tgz",
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "from": "babel-plugin-check-es2015-constants@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-arrow-functions@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-block-scoped-functions@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-block-scoping@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.22.0.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.22.1",
+              "from": "babel-traverse@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@^1.1.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@^1.0.2"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@^3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.0",
+                      "from": "js-tokens@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.22.0",
+                  "from": "babel-messages@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.15.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "debug": {
+                  "version": "2.6.0",
+                  "from": "debug@^2.2.0",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.14.0",
+                  "from": "globals@^9.0.0"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@^2.2.0",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "from": "lodash@^4.2.0"
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-classes@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.22.0.tgz",
+          "dependencies": {
+            "babel-helper-optimise-call-expression": {
+              "version": "6.22.0",
+              "from": "babel-helper-optimise-call-expression@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.22.0.tgz"
+            },
+            "babel-helper-function-name": {
+              "version": "6.22.0",
+              "from": "babel-helper-function-name@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.22.0.tgz",
+              "dependencies": {
+                "babel-helper-get-function-arity": {
+                  "version": "6.22.0",
+                  "from": "babel-helper-get-function-arity@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
+                }
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.22.0",
+              "from": "babel-helper-replace-supers@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz"
+            },
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-traverse": {
+              "version": "6.22.1",
+              "from": "babel-traverse@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@^1.1.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@^1.0.2"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@^3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.0",
+                      "from": "js-tokens@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                    }
+                  }
+                },
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.15.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "debug": {
+                  "version": "2.6.0",
+                  "from": "debug@^2.2.0",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.14.0",
+                  "from": "globals@^9.0.0"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@^2.2.0",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.22.0",
+              "from": "babel-helper-define-map@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.22.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-messages": {
+              "version": "6.22.0",
+              "from": "babel-messages@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-computed-properties@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.22.0.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.1",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-destructuring@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-duplicate-keys@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-for-of@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-function-name@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.22.0.tgz",
+          "dependencies": {
+            "babel-helper-function-name": {
+              "version": "6.22.0",
+              "from": "babel-helper-function-name@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.22.0.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.15.0",
+                      "from": "babylon@^6.15.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    }
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.22.0",
+                  "from": "babel-helper-get-function-arity@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.22.0",
+                  "from": "babel-template@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.15.0",
+                      "from": "babylon@^6.11.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-literals@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-modules-amd@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.22.0.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.1",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.22.0.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.1",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.22.0",
+              "from": "babel-plugin-transform-strict-mode@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.22.0.tgz"
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-modules-systemjs@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.22.0.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.1",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.22.0",
+              "from": "babel-helper-hoist-variables@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-modules-umd@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.22.0.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.1",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.22.0",
+                      "from": "babel-messages@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-object-super@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.22.0.tgz",
+          "dependencies": {
+            "babel-helper-replace-supers": {
+              "version": "6.22.0",
+              "from": "babel-helper-replace-supers@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.22.0.tgz",
+              "dependencies": {
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.22.0",
+                  "from": "babel-helper-optimise-call-expression@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.22.0.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.22.1",
+                  "from": "babel-traverse@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@^6.22.0",
+                      "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.0",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@^2.0.2",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    },
+                    "babylon": {
+                      "version": "6.15.0",
+                      "from": "babylon@^6.15.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.0",
+                      "from": "debug@^2.2.0",
+                      "dependencies": {
+                        "ms": {
+                          "version": "0.7.2",
+                          "from": "ms@0.7.2",
+                          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.14.0",
+                      "from": "globals@^9.0.0"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@^2.2.0",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@^1.0.0",
+                          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.0",
+                              "from": "js-tokens@^3.0.0",
+                              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.22.0",
+                  "from": "babel-messages@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.22.0",
+                  "from": "babel-template@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.15.0",
+                      "from": "babylon@^6.11.0",
+                      "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-parameters@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.22.0.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.22.1",
+              "from": "babel-traverse@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@^1.1.0",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@^1.0.2"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@^3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.0",
+                      "from": "js-tokens@^3.0.0",
+                      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.22.0",
+                  "from": "babel-messages@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.15.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "debug": {
+                  "version": "2.6.0",
+                  "from": "debug@^2.2.0",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.14.0",
+                  "from": "globals@^9.0.0"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@^2.2.0",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.22.0",
+              "from": "babel-helper-call-delegate@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.22.0.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.22.0",
+                  "from": "babel-helper-hoist-variables@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.22.0.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.22.0",
+              "from": "babel-helper-get-function-arity@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.22.0.tgz"
+            },
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.15.0",
+                  "from": "babylon@^6.11.0",
+                  "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-shorthand-properties@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.22.0.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-spread@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-sticky-regex@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.22.0.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.22.0",
+              "from": "babel-helper-regex@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-template-literals@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-unicode-regex@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.22.0.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.22.0",
+              "from": "babel-helper-regex@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.22.0.tgz",
+              "dependencies": {
+                "lodash": {
+                  "version": "4.17.4",
+                  "from": "lodash@^4.2.0"
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "from": "regexpu-core@^2.0.0",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "regenerate@^1.2.1"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@^0.1.4",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@~0.5.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-regenerator@^6.22.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.22.0.tgz",
+          "dependencies": {
+            "regenerator-transform": {
+              "version": "0.9.8",
+              "from": "regenerator-transform@0.9.8",
+              "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.8.tgz",
+              "dependencies": {
+                "babel-runtime": {
+                  "version": "6.22.0",
+                  "from": "babel-runtime@^6.18.0",
+                  "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@^2.4.0"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.1",
+                      "from": "regenerator-runtime@^0.10.0"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.22.0",
+                  "from": "babel-types@^6.22.0",
+                  "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@^2.0.2",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "lodash": {
+                      "version": "4.17.4",
+                      "from": "lodash@^4.2.0"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.2",
+                      "from": "to-fast-properties@^1.0.1"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@^0.1.6",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "grunt": {
       "version": "0.4.5",
       "from": "grunt@0.4.5",
@@ -43,9 +2287,8 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@2"
                 },
                 "minimatch": {
                   "version": "0.3.0",
@@ -53,9 +2296,8 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                      "version": "2.7.3",
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -106,9 +2348,8 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dependencies": {
             "lru-cache": {
-              "version": "2.7.0",
-              "from": "lru-cache@2",
-              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+              "version": "2.7.3",
+              "from": "lru-cache@2"
             },
             "sigmund": {
               "version": "1.0.1",
@@ -123,9 +2364,8 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dependencies": {
             "abbrev": {
-              "version": "1.0.7",
-              "from": "abbrev@1",
-              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+              "version": "1.0.9",
+              "from": "abbrev@1"
             }
           }
         },
@@ -194,13 +2434,12 @@
           "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-0.2.0.tgz"
         },
         "grunt-legacy-log": {
-          "version": "0.1.2",
+          "version": "0.1.3",
           "from": "grunt-legacy-log@~0.1.0",
-          "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-0.1.2.tgz",
           "dependencies": {
             "grunt-legacy-log-utils": {
               "version": "0.1.1",
-              "from": "grunt-legacy-log-utils@^0.1.1",
+              "from": "grunt-legacy-log-utils@~0.1.1",
               "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-0.1.1.tgz"
             },
             "lodash": {
@@ -218,299 +2457,159 @@
       }
     },
     "grunt-babel": {
-      "version": "5.0.1",
-      "from": "grunt-babel@5.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-babel/-/grunt-babel-5.0.1.tgz",
+      "version": "6.0.0",
+      "from": "grunt-babel@6.0.0",
       "dependencies": {
         "babel-core": {
-          "version": "5.8.33",
-          "from": "babel-core@^5.0.0",
-          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-5.8.33.tgz",
+          "version": "6.22.1",
+          "from": "babel-core@^6.0.12",
+          "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.22.1.tgz",
           "dependencies": {
-            "babel-plugin-constant-folding": {
-              "version": "1.0.1",
-              "from": "babel-plugin-constant-folding@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-constant-folding/-/babel-plugin-constant-folding-1.0.1.tgz"
-            },
-            "babel-plugin-dead-code-elimination": {
-              "version": "1.0.2",
-              "from": "babel-plugin-dead-code-elimination@^1.0.2",
-              "resolved": "https://registry.npmjs.org/babel-plugin-dead-code-elimination/-/babel-plugin-dead-code-elimination-1.0.2.tgz"
-            },
-            "babel-plugin-eval": {
-              "version": "1.0.1",
-              "from": "babel-plugin-eval@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-eval/-/babel-plugin-eval-1.0.1.tgz"
-            },
-            "babel-plugin-inline-environment-variables": {
-              "version": "1.0.1",
-              "from": "babel-plugin-inline-environment-variables@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-inline-environment-variables/-/babel-plugin-inline-environment-variables-1.0.1.tgz"
-            },
-            "babel-plugin-jscript": {
-              "version": "1.0.4",
-              "from": "babel-plugin-jscript@^1.0.4",
-              "resolved": "https://registry.npmjs.org/babel-plugin-jscript/-/babel-plugin-jscript-1.0.4.tgz"
-            },
-            "babel-plugin-member-expression-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-member-expression-literals@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-member-expression-literals/-/babel-plugin-member-expression-literals-1.0.1.tgz"
-            },
-            "babel-plugin-property-literals": {
-              "version": "1.0.1",
-              "from": "babel-plugin-property-literals@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-property-literals/-/babel-plugin-property-literals-1.0.1.tgz"
-            },
-            "babel-plugin-proto-to-assign": {
-              "version": "1.0.4",
-              "from": "babel-plugin-proto-to-assign@^1.0.3",
-              "resolved": "https://registry.npmjs.org/babel-plugin-proto-to-assign/-/babel-plugin-proto-to-assign-1.0.4.tgz"
-            },
-            "babel-plugin-react-constant-elements": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-constant-elements@^1.0.3",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-constant-elements/-/babel-plugin-react-constant-elements-1.0.3.tgz"
-            },
-            "babel-plugin-react-display-name": {
-              "version": "1.0.3",
-              "from": "babel-plugin-react-display-name@^1.0.3",
-              "resolved": "https://registry.npmjs.org/babel-plugin-react-display-name/-/babel-plugin-react-display-name-1.0.3.tgz"
-            },
-            "babel-plugin-remove-console": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-console@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-console/-/babel-plugin-remove-console-1.0.1.tgz"
-            },
-            "babel-plugin-remove-debugger": {
-              "version": "1.0.1",
-              "from": "babel-plugin-remove-debugger@^1.0.1",
-              "resolved": "https://registry.npmjs.org/babel-plugin-remove-debugger/-/babel-plugin-remove-debugger-1.0.1.tgz"
-            },
-            "babel-plugin-runtime": {
-              "version": "1.0.7",
-              "from": "babel-plugin-runtime@^1.0.7",
-              "resolved": "https://registry.npmjs.org/babel-plugin-runtime/-/babel-plugin-runtime-1.0.7.tgz"
-            },
-            "babel-plugin-undeclared-variables-check": {
-              "version": "1.0.2",
-              "from": "babel-plugin-undeclared-variables-check@^1.0.2",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undeclared-variables-check/-/babel-plugin-undeclared-variables-check-1.0.2.tgz",
+            "babel-code-frame": {
+              "version": "6.22.0",
+              "from": "babel-code-frame@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
               "dependencies": {
-                "leven": {
-                  "version": "1.0.2",
-                  "from": "leven@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/leven/-/leven-1.0.2.tgz"
-                }
-              }
-            },
-            "babel-plugin-undefined-to-void": {
-              "version": "1.1.6",
-              "from": "babel-plugin-undefined-to-void@^1.1.6",
-              "resolved": "https://registry.npmjs.org/babel-plugin-undefined-to-void/-/babel-plugin-undefined-to-void-1.1.6.tgz"
-            },
-            "babylon": {
-              "version": "5.8.29",
-              "from": "babylon@^5.8.29",
-              "resolved": "https://registry.npmjs.org/babylon/-/babylon-5.8.29.tgz"
-            },
-            "bluebird": {
-              "version": "2.10.2",
-              "from": "bluebird@^2.9.33",
-              "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
-            },
-            "chalk": {
-              "version": "1.1.1",
-              "from": "chalk@^1.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.1.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@^2.1.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.3",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                "chalk": {
+                  "version": "1.1.3",
+                  "from": "chalk@^1.1.0",
                   "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.0",
-                  "from": "strip-ansi@^3.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.0.0",
-                      "from": "ansi-regex@^2.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@^2.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "convert-source-map": {
-              "version": "1.1.1",
-              "from": "convert-source-map@^1.1.0",
-              "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.1.tgz"
-            },
-            "core-js": {
-              "version": "1.2.5",
-              "from": "core-js@^1.0.0",
-              "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.5.tgz"
-            },
-            "debug": {
-              "version": "2.2.0",
-              "from": "debug@^2.1.1",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-                }
-              }
-            },
-            "detect-indent": {
-              "version": "3.0.1",
-              "from": "detect-indent@^3.0.0",
-              "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-3.0.1.tgz",
-              "dependencies": {
-                "get-stdin": {
-                  "version": "4.0.1",
-                  "from": "get-stdin@^4.0.1",
-                  "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@^1.1.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@^2.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "fs-readdir-recursive": {
-              "version": "0.1.2",
-              "from": "fs-readdir-recursive@^0.1.0",
-              "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-0.1.2.tgz"
-            },
-            "globals": {
-              "version": "6.4.1",
-              "from": "globals@^6.4.0",
-              "resolved": "https://registry.npmjs.org/globals/-/globals-6.4.1.tgz"
-            },
-            "home-or-tmp": {
-              "version": "1.0.0",
-              "from": "home-or-tmp@^1.0.0",
-              "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-1.0.0.tgz",
-              "dependencies": {
-                "os-tmpdir": {
-                  "version": "1.0.1",
-                  "from": "os-tmpdir@^1.0.1",
-                  "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                },
-                "user-home": {
-                  "version": "1.1.1",
-                  "from": "user-home@^1.1.1",
-                  "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
-                }
-              }
-            },
-            "is-integer": {
-              "version": "1.0.6",
-              "from": "is-integer@^1.0.4",
-              "resolved": "https://registry.npmjs.org/is-integer/-/is-integer-1.0.6.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "js-tokens": {
-              "version": "1.0.1",
-              "from": "js-tokens@1.0.1",
-              "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-1.0.1.tgz"
-            },
-            "json5": {
-              "version": "0.4.0",
-              "from": "json5@^0.4.0",
-              "resolved": "https://registry.npmjs.org/json5/-/json5-0.4.0.tgz"
-            },
-            "line-numbers": {
-              "version": "0.2.0",
-              "from": "line-numbers@0.2.0",
-              "resolved": "https://registry.npmjs.org/line-numbers/-/line-numbers-0.2.0.tgz",
-              "dependencies": {
-                "left-pad": {
-                  "version": "0.0.3",
-                  "from": "left-pad@0.0.3",
-                  "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-0.0.3.tgz"
-                }
-              }
-            },
-            "lodash": {
-              "version": "3.10.1",
-              "from": "lodash@^3.10.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
-            },
-            "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@^2.0.3",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.1",
-                  "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                    "ansi-styles": {
+                      "version": "2.2.1",
+                      "from": "ansi-styles@^2.2.1"
                     },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@^1.0.2"
+                    },
+                    "has-ansi": {
+                      "version": "2.0.0",
+                      "from": "has-ansi@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "ansi-regex@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@^3.0.0",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "ansi-regex@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "supports-color": {
+                      "version": "2.0.0",
+                      "from": "supports-color@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                     }
                   }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "js-tokens": {
+                  "version": "3.0.0",
+                  "from": "js-tokens@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
                 }
               }
             },
-            "output-file-sync": {
-              "version": "1.1.1",
-              "from": "output-file-sync@^1.1.0",
-              "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.1.tgz",
+            "babel-generator": {
+              "version": "6.22.0",
+              "from": "babel-generator@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.22.0.tgz",
               "dependencies": {
+                "detect-indent": {
+                  "version": "4.0.0",
+                  "from": "detect-indent@^4.0.0",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "2.0.1",
+                      "from": "repeating@^2.0.0",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.2",
+                          "from": "is-finite@^1.0.0",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "from": "number-is-nan@^1.0.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "jsesc": {
+                  "version": "1.3.0",
+                  "from": "jsesc@^1.3.0"
+                }
+              }
+            },
+            "babel-helpers": {
+              "version": "6.22.0",
+              "from": "babel-helpers@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.22.0.tgz"
+            },
+            "babel-messages": {
+              "version": "6.22.0",
+              "from": "babel-messages@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.22.0.tgz"
+            },
+            "babel-template": {
+              "version": "6.22.0",
+              "from": "babel-template@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.22.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.22.0",
+              "from": "babel-runtime@^6.18.0",
+              "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.1",
+                  "from": "regenerator-runtime@^0.10.0"
+                }
+              }
+            },
+            "babel-register": {
+              "version": "6.22.0",
+              "from": "babel-register@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.22.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@^2.4.0"
+                },
+                "home-or-tmp": {
+                  "version": "2.0.0",
+                  "from": "home-or-tmp@^2.0.0",
+                  "dependencies": {
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "from": "os-homedir@^1.0.0"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "from": "os-tmpdir@^1.0.1"
+                    }
+                  }
+                },
                 "mkdirp": {
                   "version": "0.5.1",
                   "from": "mkdirp@^0.5.1",
@@ -523,424 +2622,115 @@
                     }
                   }
                 },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@^4.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                "source-map-support": {
+                  "version": "0.4.10",
+                  "from": "source-map-support@^0.4.2",
+                  "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.10.tgz"
                 }
               }
             },
-            "path-exists": {
-              "version": "1.0.0",
-              "from": "path-exists@^1.0.0",
-              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-1.0.0.tgz"
+            "babel-traverse": {
+              "version": "6.22.1",
+              "from": "babel-traverse@^6.22.1",
+              "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.22.1.tgz",
+              "dependencies": {
+                "globals": {
+                  "version": "9.14.0",
+                  "from": "globals@^9.0.0"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@^2.2.0",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@^1.0.0",
+                      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.0",
+                          "from": "js-tokens@^3.0.0",
+                          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.22.0",
+              "from": "babel-types@^6.22.0",
+              "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.22.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@^2.0.2",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.2",
+                  "from": "to-fast-properties@^1.0.1"
+                }
+              }
+            },
+            "babylon": {
+              "version": "6.15.0",
+              "from": "babylon@^6.15.0",
+              "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.15.0.tgz"
+            },
+            "convert-source-map": {
+              "version": "1.3.0",
+              "from": "convert-source-map@^1.1.0"
+            },
+            "debug": {
+              "version": "2.6.0",
+              "from": "debug@^2.2.0",
+              "dependencies": {
+                "ms": {
+                  "version": "0.7.2",
+                  "from": "ms@0.7.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                }
+              }
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@^0.5.0"
+            },
+            "lodash": {
+              "version": "4.17.4",
+              "from": "lodash@^4.2.0"
+            },
+            "minimatch": {
+              "version": "3.0.3",
+              "from": "minimatch@~3.0.2",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.6",
+                  "from": "brace-expansion@^1.0.0",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@^0.4.1"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
             },
             "path-is-absolute": {
-              "version": "1.0.0",
-              "from": "path-is-absolute@^1.0.0",
-              "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+              "version": "1.0.1",
+              "from": "path-is-absolute@^1.0.0"
             },
             "private": {
               "version": "0.1.6",
               "from": "private@^0.1.6",
               "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
-            },
-            "regenerator": {
-              "version": "0.8.40",
-              "from": "regenerator@0.8.40",
-              "resolved": "https://registry.npmjs.org/regenerator/-/regenerator-0.8.40.tgz",
-              "dependencies": {
-                "commoner": {
-                  "version": "0.10.4",
-                  "from": "commoner@~0.10.3",
-                  "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.4.tgz",
-                  "dependencies": {
-                    "commander": {
-                      "version": "2.9.0",
-                      "from": "commander@^2.5.0",
-                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                      "dependencies": {
-                        "graceful-readlink": {
-                          "version": "1.0.1",
-                          "from": "graceful-readlink@>= 1.0.0",
-                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "detective": {
-                      "version": "4.3.1",
-                      "from": "detective@^4.3.1",
-                      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.1.tgz",
-                      "dependencies": {
-                        "acorn": {
-                          "version": "1.2.2",
-                          "from": "acorn@^1.0.3",
-                          "resolved": "https://registry.npmjs.org/acorn/-/acorn-1.2.2.tgz"
-                        },
-                        "defined": {
-                          "version": "1.0.0",
-                          "from": "defined@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "glob": {
-                      "version": "5.0.15",
-                      "from": "glob@^5.0.15",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
-                      "dependencies": {
-                        "inflight": {
-                          "version": "1.0.4",
-                          "from": "inflight@^1.0.4",
-                          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@2",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        },
-                        "once": {
-                          "version": "1.3.2",
-                          "from": "once@^1.3.0",
-                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                          "dependencies": {
-                            "wrappy": {
-                              "version": "1.0.1",
-                              "from": "wrappy@1",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@^4.1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.13",
-                      "from": "iconv-lite@^0.4.5",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@^0.5.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "q": {
-                      "version": "1.4.1",
-                      "from": "q@^1.1.2",
-                      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
-                    }
-                  }
-                },
-                "defs": {
-                  "version": "1.1.1",
-                  "from": "defs@~1.1.0",
-                  "resolved": "https://registry.npmjs.org/defs/-/defs-1.1.1.tgz",
-                  "dependencies": {
-                    "alter": {
-                      "version": "0.2.0",
-                      "from": "alter@~0.2.0",
-                      "resolved": "https://registry.npmjs.org/alter/-/alter-0.2.0.tgz",
-                      "dependencies": {
-                        "stable": {
-                          "version": "0.1.5",
-                          "from": "stable@~0.1.3",
-                          "resolved": "https://registry.npmjs.org/stable/-/stable-0.1.5.tgz"
-                        }
-                      }
-                    },
-                    "ast-traverse": {
-                      "version": "0.1.1",
-                      "from": "ast-traverse@~0.1.1",
-                      "resolved": "https://registry.npmjs.org/ast-traverse/-/ast-traverse-0.1.1.tgz"
-                    },
-                    "breakable": {
-                      "version": "1.0.0",
-                      "from": "breakable@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/breakable/-/breakable-1.0.0.tgz"
-                    },
-                    "simple-fmt": {
-                      "version": "0.1.0",
-                      "from": "simple-fmt@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/simple-fmt/-/simple-fmt-0.1.0.tgz"
-                    },
-                    "simple-is": {
-                      "version": "0.2.0",
-                      "from": "simple-is@~0.2.0",
-                      "resolved": "https://registry.npmjs.org/simple-is/-/simple-is-0.2.0.tgz"
-                    },
-                    "stringmap": {
-                      "version": "0.2.2",
-                      "from": "stringmap@~0.2.2",
-                      "resolved": "https://registry.npmjs.org/stringmap/-/stringmap-0.2.2.tgz"
-                    },
-                    "stringset": {
-                      "version": "0.2.1",
-                      "from": "stringset@~0.2.1",
-                      "resolved": "https://registry.npmjs.org/stringset/-/stringset-0.2.1.tgz"
-                    },
-                    "tryor": {
-                      "version": "0.1.2",
-                      "from": "tryor@~0.1.2",
-                      "resolved": "https://registry.npmjs.org/tryor/-/tryor-0.1.2.tgz"
-                    },
-                    "yargs": {
-                      "version": "3.27.0",
-                      "from": "yargs@~3.27.0",
-                      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.27.0.tgz",
-                      "dependencies": {
-                        "camelcase": {
-                          "version": "1.2.1",
-                          "from": "camelcase@^1.2.1",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                        },
-                        "cliui": {
-                          "version": "2.1.0",
-                          "from": "cliui@^2.1.0",
-                          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                          "dependencies": {
-                            "center-align": {
-                              "version": "0.1.2",
-                              "from": "center-align@^0.1.1",
-                              "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.2.tgz",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.3",
-                                  "from": "align-text@^0.1.0",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "2.0.1",
-                                      "from": "kind-of@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.0",
-                                          "from": "is-buffer@^1.0.2",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@^1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@^1.5.2",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                    }
-                                  }
-                                },
-                                "lazy-cache": {
-                                  "version": "0.2.4",
-                                  "from": "lazy-cache@^0.2.4",
-                                  "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.4.tgz"
-                                }
-                              }
-                            },
-                            "right-align": {
-                              "version": "0.1.3",
-                              "from": "right-align@^0.1.1",
-                              "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                              "dependencies": {
-                                "align-text": {
-                                  "version": "0.1.3",
-                                  "from": "align-text@^0.1.1",
-                                  "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.3.tgz",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "2.0.1",
-                                      "from": "kind-of@^2.0.0",
-                                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.0",
-                                          "from": "is-buffer@^1.0.2",
-                                          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "longest": {
-                                      "version": "1.0.1",
-                                      "from": "longest@^1.0.1",
-                                      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.5.2",
-                                      "from": "repeat-string@^1.5.2",
-                                      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.5.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "wordwrap": {
-                              "version": "0.0.2",
-                              "from": "wordwrap@0.0.2",
-                              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                            }
-                          }
-                        },
-                        "decamelize": {
-                          "version": "1.1.1",
-                          "from": "decamelize@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.1.1.tgz"
-                        },
-                        "os-locale": {
-                          "version": "1.4.0",
-                          "from": "os-locale@^1.4.0",
-                          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                          "dependencies": {
-                            "lcid": {
-                              "version": "1.0.0",
-                              "from": "lcid@^1.0.0",
-                              "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                              "dependencies": {
-                                "invert-kv": {
-                                  "version": "1.0.0",
-                                  "from": "invert-kv@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "window-size": {
-                          "version": "0.1.2",
-                          "from": "window-size@^0.1.2",
-                          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.2.tgz"
-                        },
-                        "y18n": {
-                          "version": "3.2.0",
-                          "from": "y18n@^3.2.0",
-                          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "esprima-fb": {
-                  "version": "15001.1001.0-dev-harmony-fb",
-                  "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                },
-                "recast": {
-                  "version": "0.10.33",
-                  "from": "recast@0.10.33",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.33.tgz",
-                  "dependencies": {
-                    "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@0.8.12",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                    }
-                  }
-                },
-                "through": {
-                  "version": "2.3.8",
-                  "from": "through@~2.3.8",
-                  "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-                }
-              }
-            },
-            "regexpu": {
-              "version": "1.3.0",
-              "from": "regexpu@^1.3.0",
-              "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-1.3.0.tgz",
-              "dependencies": {
-                "esprima": {
-                  "version": "2.7.0",
-                  "from": "esprima@^2.6.0",
-                  "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.0.tgz"
-                },
-                "recast": {
-                  "version": "0.10.37",
-                  "from": "recast@^0.10.10",
-                  "resolved": "https://registry.npmjs.org/recast/-/recast-0.10.37.tgz",
-                  "dependencies": {
-                    "esprima-fb": {
-                      "version": "15001.1001.0-dev-harmony-fb",
-                      "from": "esprima-fb@~15001.1001.0-dev-harmony-fb",
-                      "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1001.0-dev-harmony-fb.tgz"
-                    },
-                    "ast-types": {
-                      "version": "0.8.12",
-                      "from": "ast-types@0.8.12",
-                      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.8.12.tgz"
-                    }
-                  }
-                },
-                "regenerate": {
-                  "version": "1.2.1",
-                  "from": "regenerate@^1.2.1",
-                  "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.2.1.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@^0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "from": "regjsparser@^0.1.4",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "repeating": {
-              "version": "1.1.3",
-              "from": "repeating@^1.1.2",
-              "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
-              "dependencies": {
-                "is-finite": {
-                  "version": "1.0.1",
-                  "from": "is-finite@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.0",
-                      "from": "number-is-nan@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "resolve": {
-              "version": "1.1.6",
-              "from": "resolve@^1.1.6",
-              "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.6.tgz"
-            },
-            "shebang-regex": {
-              "version": "1.0.0",
-              "from": "shebang-regex@^1.0.0",
-              "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz"
             },
             "slash": {
               "version": "1.0.0",
@@ -948,43 +2738,8 @@
               "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
             },
             "source-map": {
-              "version": "0.5.3",
-              "from": "source-map@^0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.3.tgz"
-            },
-            "source-map-support": {
-              "version": "0.2.10",
-              "from": "source-map-support@^0.2.10",
-              "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.10.tgz",
-              "dependencies": {
-                "source-map": {
-                  "version": "0.1.32",
-                  "from": "source-map@0.1.32",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.0",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "to-fast-properties": {
-              "version": "1.0.1",
-              "from": "to-fast-properties@^1.0.0",
-              "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.1.tgz"
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "from": "trim-right@^1.0.0",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-            },
-            "try-resolve": {
-              "version": "1.0.1",
-              "from": "try-resolve@^1.0.0",
-              "resolved": "https://registry.npmjs.org/try-resolve/-/try-resolve-1.0.1.tgz"
+              "version": "0.5.6",
+              "from": "source-map@^0.5.0"
             }
           }
         }
@@ -1045,14 +2800,17 @@
                   }
                 },
                 "raw-body": {
-                  "version": "2.1.4",
+                  "version": "2.1.7",
                   "from": "raw-body@~2.1.2",
-                  "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.4.tgz",
                   "dependencies": {
+                    "bytes": {
+                      "version": "2.4.0",
+                      "from": "bytes@2.4.0"
+                    },
                     "iconv-lite": {
-                      "version": "0.4.12",
-                      "from": "iconv-lite@0.4.12",
-                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.12.tgz"
+                      "version": "0.4.13",
+                      "from": "iconv-lite@0.4.13",
+                      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
                     },
                     "unpipe": {
                       "version": "1.0.0",
@@ -1094,14 +2852,14 @@
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.1.7",
-                      "from": "mime-types@~2.1.6",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                      "version": "2.1.14",
+                      "from": "mime-types@~2.1.11",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.19.0",
-                          "from": "mime-db@~1.19.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                          "version": "1.26.0",
+                          "from": "mime-db@~1.26.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                         }
                       }
                     },
@@ -1113,14 +2871,13 @@
                   }
                 },
                 "compressible": {
-                  "version": "2.0.6",
+                  "version": "2.0.9",
                   "from": "compressible@~2.0.5",
-                  "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.6.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@~1.19.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                      "version": "1.26.0",
+                      "from": "mime-db@~1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                     }
                   }
                 },
@@ -1144,9 +2901,8 @@
               }
             },
             "content-type": {
-              "version": "1.0.1",
-              "from": "content-type@~1.0.1",
-              "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.1.tgz"
+              "version": "1.0.2",
+              "from": "content-type@~1.0.1"
             },
             "csurf": {
               "version": "1.8.3",
@@ -1154,29 +2910,35 @@
               "resolved": "https://registry.npmjs.org/csurf/-/csurf-1.8.3.tgz",
               "dependencies": {
                 "csrf": {
-                  "version": "3.0.0",
+                  "version": "3.0.4",
                   "from": "csrf@~3.0.0",
-                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.0.tgz",
+                  "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.4.tgz",
                   "dependencies": {
                     "base64-url": {
-                      "version": "1.2.1",
-                      "from": "base64-url@1.2.1",
-                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+                      "version": "1.3.3",
+                      "from": "base64-url@1.3.3",
+                      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.3.3.tgz"
                     },
                     "rndm": {
-                      "version": "1.1.1",
-                      "from": "rndm@~1.1.0",
-                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.1.1.tgz"
+                      "version": "1.2.0",
+                      "from": "rndm@1.2.0",
+                      "resolved": "https://registry.npmjs.org/rndm/-/rndm-1.2.0.tgz"
                     },
-                    "scmp": {
-                      "version": "1.0.0",
-                      "from": "scmp@1.0.0",
-                      "resolved": "https://registry.npmjs.org/scmp/-/scmp-1.0.0.tgz"
+                    "tsscmp": {
+                      "version": "1.0.5",
+                      "from": "tsscmp@1.0.5",
+                      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz"
                     },
                     "uid-safe": {
-                      "version": "2.0.0",
-                      "from": "uid-safe@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz"
+                      "version": "2.1.3",
+                      "from": "uid-safe@2.1.3",
+                      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.3.tgz",
+                      "dependencies": {
+                        "random-bytes": {
+                          "version": "1.0.0",
+                          "from": "random-bytes@~1.0.0"
+                        }
+                      }
                     }
                   }
                 }
@@ -1200,38 +2962,35 @@
               "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
             },
             "errorhandler": {
-              "version": "1.4.2",
+              "version": "1.4.3",
               "from": "errorhandler@~1.4.2",
-              "resolved": "https://registry.npmjs.org/errorhandler/-/errorhandler-1.4.2.tgz",
               "dependencies": {
                 "accepts": {
-                  "version": "1.2.13",
-                  "from": "accepts@~1.2.12",
-                  "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
+                  "version": "1.3.3",
+                  "from": "accepts@~1.3.0",
                   "dependencies": {
                     "mime-types": {
-                      "version": "2.1.7",
-                      "from": "mime-types@~2.1.6",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                      "version": "2.1.14",
+                      "from": "mime-types@~2.1.11",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                       "dependencies": {
                         "mime-db": {
-                          "version": "1.19.0",
-                          "from": "mime-db@~1.19.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                          "version": "1.26.0",
+                          "from": "mime-db@~1.26.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                         }
                       }
                     },
                     "negotiator": {
-                      "version": "0.5.3",
-                      "from": "negotiator@0.5.3",
-                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.3.tgz"
+                      "version": "0.6.1",
+                      "from": "negotiator@0.6.1",
+                      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
                     }
                   }
                 },
                 "escape-html": {
-                  "version": "1.0.2",
-                  "from": "escape-html@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "escape-html@~1.0.3"
                 }
               }
             },
@@ -1299,31 +3058,39 @@
               "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
               "dependencies": {
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@~2.0.1",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@~2.0.1"
                 },
                 "statuses": {
-                  "version": "1.2.1",
-                  "from": "statuses@1",
-                  "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.2.1.tgz"
+                  "version": "1.3.1",
+                  "from": "statuses@1"
                 }
               }
             },
             "method-override": {
-              "version": "2.3.5",
+              "version": "2.3.7",
               "from": "method-override@~2.3.5",
-              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.5.tgz",
+              "resolved": "https://registry.npmjs.org/method-override/-/method-override-2.3.7.tgz",
               "dependencies": {
+                "debug": {
+                  "version": "2.3.3",
+                  "from": "debug@2.3.3",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                    }
+                  }
+                },
                 "methods": {
-                  "version": "1.1.1",
-                  "from": "methods@~1.1.1",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+                  "version": "1.1.2",
+                  "from": "methods@~1.1.2"
                 },
                 "vary": {
-                  "version": "1.0.1",
-                  "from": "vary@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.1.tgz"
+                  "version": "1.1.0",
+                  "from": "vary@~1.1.0"
                 }
               }
             },
@@ -1333,9 +3100,8 @@
               "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.6.1.tgz",
               "dependencies": {
                 "basic-auth": {
-                  "version": "1.0.3",
-                  "from": "basic-auth@~1.0.3",
-                  "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.0.3.tgz"
+                  "version": "1.0.4",
+                  "from": "basic-auth@~1.0.3"
                 },
                 "on-finished": {
                   "version": "2.3.0",
@@ -1357,14 +3123,13 @@
               "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-3.3.2.tgz",
               "dependencies": {
                 "readable-stream": {
-                  "version": "1.1.13",
+                  "version": "1.1.14",
                   "from": "readable-stream@~1.1.9",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -1377,9 +3142,8 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "inherits@2"
                     }
                   }
                 },
@@ -1396,9 +3160,8 @@
               "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
             },
             "parseurl": {
-              "version": "1.3.0",
-              "from": "parseurl@~1.3.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+              "version": "1.3.1",
+              "from": "parseurl@~1.3.0"
             },
             "pause": {
               "version": "0.1.0",
@@ -1411,14 +3174,20 @@
               "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz"
             },
             "response-time": {
-              "version": "2.3.1",
+              "version": "2.3.2",
               "from": "response-time@~2.3.1",
-              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/response-time/-/response-time-2.3.2.tgz",
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "depd@~1.1.0"
+                }
+              }
             },
             "serve-favicon": {
-              "version": "2.3.0",
+              "version": "2.3.2",
               "from": "serve-favicon@~2.3.0",
-              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.0.tgz",
+              "resolved": "https://registry.npmjs.org/serve-favicon/-/serve-favicon-2.3.2.tgz",
               "dependencies": {
                 "etag": {
                   "version": "1.7.0",
@@ -1426,20 +3195,19 @@
                   "resolved": "https://registry.npmjs.org/etag/-/etag-1.7.0.tgz"
                 },
                 "ms": {
-                  "version": "0.7.1",
-                  "from": "ms@0.7.1",
-                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
+                  "version": "0.7.2",
+                  "from": "ms@0.7.2",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
                 }
               }
             },
             "serve-index": {
-              "version": "1.7.2",
+              "version": "1.7.3",
               "from": "serve-index@~1.7.2",
-              "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.7.2.tgz",
               "dependencies": {
                 "accepts": {
                   "version": "1.2.13",
-                  "from": "accepts@~1.2.12",
+                  "from": "accepts@~1.2.13",
                   "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.13.tgz",
                   "dependencies": {
                     "negotiator": {
@@ -1450,48 +3218,48 @@
                   }
                 },
                 "batch": {
-                  "version": "0.5.2",
-                  "from": "batch@0.5.2",
-                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.2.tgz"
+                  "version": "0.5.3",
+                  "from": "batch@0.5.3",
+                  "resolved": "https://registry.npmjs.org/batch/-/batch-0.5.3.tgz"
                 },
                 "escape-html": {
-                  "version": "1.0.2",
-                  "from": "escape-html@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "escape-html@~1.0.3"
                 },
                 "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@~2.1.4",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "version": "2.1.14",
+                  "from": "mime-types@~2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@~1.19.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                      "version": "1.26.0",
+                      "from": "mime-db@~1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                     }
                   }
                 }
               }
             },
             "serve-static": {
-              "version": "1.10.0",
+              "version": "1.10.3",
               "from": "serve-static@~1.10.0",
-              "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.10.0.tgz",
               "dependencies": {
                 "escape-html": {
-                  "version": "1.0.2",
-                  "from": "escape-html@1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "escape-html@~1.0.3"
                 },
                 "send": {
-                  "version": "0.13.0",
-                  "from": "send@0.13.0",
-                  "resolved": "https://registry.npmjs.org/send/-/send-0.13.0.tgz",
+                  "version": "0.13.2",
+                  "from": "send@0.13.2",
+                  "resolved": "https://registry.npmjs.org/send/-/send-0.13.2.tgz",
                   "dependencies": {
+                    "depd": {
+                      "version": "1.1.0",
+                      "from": "depd@~1.1.0"
+                    },
                     "destroy": {
-                      "version": "1.0.3",
-                      "from": "destroy@1.0.3",
-                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+                      "version": "1.0.4",
+                      "from": "destroy@~1.0.4"
                     },
                     "etag": {
                       "version": "1.7.0",
@@ -1522,7 +3290,7 @@
                     },
                     "range-parser": {
                       "version": "1.0.3",
-                      "from": "range-parser@~1.0.2",
+                      "from": "range-parser@~1.0.3",
                       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.3.tgz"
                     },
                     "statuses": {
@@ -1535,9 +3303,8 @@
               }
             },
             "type-is": {
-              "version": "1.6.9",
+              "version": "1.6.14",
               "from": "type-is@~1.6.6",
-              "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.9.tgz",
               "dependencies": {
                 "media-typer": {
                   "version": "0.3.0",
@@ -1545,14 +3312,14 @@
                   "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
                 },
                 "mime-types": {
-                  "version": "2.1.7",
-                  "from": "mime-types@~2.1.6",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.7.tgz",
+                  "version": "2.1.14",
+                  "from": "mime-types@2.1.14",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                   "dependencies": {
                     "mime-db": {
-                      "version": "1.19.0",
-                      "from": "mime-db@~1.19.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.19.0.tgz"
+                      "version": "1.26.0",
+                      "from": "mime-db@~1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                     }
                   }
                 }
@@ -1571,9 +3338,8 @@
           }
         },
         "connect-livereload": {
-          "version": "0.5.3",
-          "from": "connect-livereload@^0.5.0",
-          "resolved": "https://registry.npmjs.org/connect-livereload/-/connect-livereload-0.5.3.tgz"
+          "version": "0.5.4",
+          "from": "connect-livereload@^0.5.0"
         },
         "opn": {
           "version": "1.0.2",
@@ -1581,14 +3347,13 @@
           "resolved": "https://registry.npmjs.org/opn/-/opn-1.0.2.tgz"
         },
         "portscanner": {
-          "version": "1.0.0",
+          "version": "1.2.0",
           "from": "portscanner@^1.0.0",
-          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.2.0.tgz",
           "dependencies": {
             "async": {
-              "version": "0.1.15",
-              "from": "async@0.1.15",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+              "version": "1.5.2",
+              "from": "async@1.5.2"
             }
           }
         }
@@ -1627,76 +3392,148 @@
               }
             },
             "phantomjs": {
-              "version": "1.9.18",
+              "version": "1.9.20",
               "from": "phantomjs@~1.9.0-1",
-              "resolved": "https://registry.npmjs.org/phantomjs/-/phantomjs-1.9.18.tgz",
               "dependencies": {
-                "adm-zip": {
-                  "version": "0.4.4",
-                  "from": "adm-zip@0.4.4",
-                  "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.4.tgz"
+                "extract-zip": {
+                  "version": "1.5.0",
+                  "from": "extract-zip@~1.5.0",
+                  "dependencies": {
+                    "concat-stream": {
+                      "version": "1.5.0",
+                      "from": "concat-stream@1.5.0",
+                      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.0.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "inherits@~2.0.1"
+                        },
+                        "typedarray": {
+                          "version": "0.0.6",
+                          "from": "typedarray@~0.0.5"
+                        },
+                        "readable-stream": {
+                          "version": "2.0.6",
+                          "from": "readable-stream@~2.0.0",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@~1.0.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "1.0.0",
+                              "from": "isarray@~1.0.0"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@~1.0.6"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@~0.10.x",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@~1.0.1"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "debug": {
+                      "version": "0.7.4",
+                      "from": "debug@0.7.4",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.0",
+                      "from": "mkdirp@0.5.0",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "yauzl": {
+                      "version": "2.4.1",
+                      "from": "yauzl@2.4.1",
+                      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+                      "dependencies": {
+                        "fd-slicer": {
+                          "version": "1.0.1",
+                          "from": "fd-slicer@~1.0.1",
+                          "dependencies": {
+                            "pend": {
+                              "version": "1.2.0",
+                              "from": "pend@~1.2.0"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
                 },
                 "fs-extra": {
-                  "version": "0.23.1",
-                  "from": "fs-extra@~0.23.1",
-                  "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.23.1.tgz",
+                  "version": "0.26.7",
+                  "from": "fs-extra@~0.26.4",
                   "dependencies": {
                     "graceful-fs": {
-                      "version": "4.1.2",
-                      "from": "graceful-fs@^4.1.2",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.2.tgz"
+                      "version": "4.1.11",
+                      "from": "graceful-fs@^4.1.2"
                     },
                     "jsonfile": {
-                      "version": "2.2.3",
-                      "from": "jsonfile@^2.1.0",
-                      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.2.3.tgz"
+                      "version": "2.4.0",
+                      "from": "jsonfile@^2.1.0"
+                    },
+                    "klaw": {
+                      "version": "1.3.1",
+                      "from": "klaw@^1.0.0"
                     },
                     "path-is-absolute": {
-                      "version": "1.0.0",
-                      "from": "path-is-absolute@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@^1.0.0"
                     },
                     "rimraf": {
-                      "version": "2.4.3",
+                      "version": "2.5.4",
                       "from": "rimraf@^2.2.8",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.3.tgz",
                       "dependencies": {
                         "glob": {
-                          "version": "5.0.15",
-                          "from": "glob@^5.0.14",
-                          "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
+                          "version": "7.1.1",
+                          "from": "glob@^7.0.5",
                           "dependencies": {
+                            "fs.realpath": {
+                              "version": "1.0.0",
+                              "from": "fs.realpath@^1.0.0"
+                            },
                             "inflight": {
-                              "version": "1.0.4",
+                              "version": "1.0.6",
                               "from": "inflight@^1.0.4",
-                              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.2",
+                                  "from": "wrappy@1"
                                 }
                               }
                             },
                             "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@2",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                              "version": "2.0.3",
+                              "from": "inherits@2"
                             },
                             "minimatch": {
-                              "version": "3.0.0",
-                              "from": "minimatch@2 || 3",
-                              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.0.tgz",
+                              "version": "3.0.3",
+                              "from": "minimatch@^3.0.2",
                               "dependencies": {
                                 "brace-expansion": {
-                                  "version": "1.1.1",
+                                  "version": "1.1.6",
                                   "from": "brace-expansion@^1.0.0",
-                                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                                   "dependencies": {
                                     "balanced-match": {
-                                      "version": "0.2.1",
-                                      "from": "balanced-match@^0.2.0",
-                                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                                      "version": "0.4.2",
+                                      "from": "balanced-match@^0.4.1"
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
@@ -1708,14 +3545,12 @@
                               }
                             },
                             "once": {
-                              "version": "1.3.2",
+                              "version": "1.4.0",
                               "from": "once@^1.3.0",
-                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                               "dependencies": {
                                 "wrappy": {
-                                  "version": "1.0.1",
-                                  "from": "wrappy@1",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                                  "version": "1.0.2",
+                                  "from": "wrappy@1"
                                 }
                               }
                             }
@@ -1725,298 +3560,389 @@
                     }
                   }
                 },
-                "kew": {
-                  "version": "0.4.0",
-                  "from": "kew@0.4.0",
-                  "resolved": "https://registry.npmjs.org/kew/-/kew-0.4.0.tgz"
-                },
-                "npmconf": {
-                  "version": "2.1.1",
-                  "from": "npmconf@2.1.1",
-                  "resolved": "https://registry.npmjs.org/npmconf/-/npmconf-2.1.1.tgz",
+                "hasha": {
+                  "version": "2.2.0",
+                  "from": "hasha@^2.2.0",
                   "dependencies": {
-                    "config-chain": {
-                      "version": "1.1.9",
-                      "from": "config-chain@~1.1.8",
-                      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.9.tgz",
-                      "dependencies": {
-                        "proto-list": {
-                          "version": "1.2.4",
-                          "from": "proto-list@~1.2.1",
-                          "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz"
-                        }
-                      }
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "from": "is-stream@^1.0.1"
                     },
-                    "inherits": {
+                    "pinkie-promise": {
                       "version": "2.0.1",
-                      "from": "inherits@~2.0.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                    },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@^1.2.0",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@^0.5.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "from": "pinkie-promise@^2.0.0",
                       "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@^2.0.0"
                         }
                       }
-                    },
-                    "nopt": {
-                      "version": "3.0.4",
-                      "from": "nopt@~3.0.1",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.4.tgz",
-                      "dependencies": {
-                        "abbrev": {
-                          "version": "1.0.7",
-                          "from": "abbrev@1",
-                          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
-                        }
-                      }
-                    },
-                    "once": {
-                      "version": "1.3.2",
-                      "from": "once@~1.3.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
-                      "dependencies": {
-                        "wrappy": {
-                          "version": "1.0.1",
-                          "from": "wrappy@1",
-                          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "osenv": {
-                      "version": "0.1.3",
-                      "from": "osenv@^0.1.0",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.3.tgz",
-                      "dependencies": {
-                        "os-homedir": {
-                          "version": "1.0.1",
-                          "from": "os-homedir@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.1.tgz"
-                        },
-                        "os-tmpdir": {
-                          "version": "1.0.1",
-                          "from": "os-tmpdir@^1.0.0",
-                          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "semver": {
-                      "version": "4.3.6",
-                      "from": "semver@2 || 3 || 4",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
-                    },
-                    "uid-number": {
-                      "version": "0.0.5",
-                      "from": "uid-number@0.0.5",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.5.tgz"
                     }
                   }
                 },
+                "kew": {
+                  "version": "0.7.0",
+                  "from": "kew@~0.7.0"
+                },
                 "progress": {
                   "version": "1.1.8",
-                  "from": "progress@1.1.8",
+                  "from": "progress@~1.1.8",
                   "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
                 },
                 "request": {
-                  "version": "2.42.0",
-                  "from": "request@2.42.0",
-                  "resolved": "https://registry.npmjs.org/request/-/request-2.42.0.tgz",
+                  "version": "2.67.0",
+                  "from": "request@~2.67.0",
                   "dependencies": {
                     "bl": {
-                      "version": "0.9.4",
-                      "from": "bl@~0.9.0",
-                      "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                      "version": "1.0.3",
+                      "from": "bl@~1.0.0",
                       "dependencies": {
                         "readable-stream": {
-                          "version": "1.0.33",
-                          "from": "readable-stream@~1.0.26",
-                          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                          "version": "2.0.6",
+                          "from": "readable-stream@~2.0.5",
                           "dependencies": {
                             "core-util-is": {
-                              "version": "1.0.1",
+                              "version": "1.0.2",
                               "from": "core-util-is@~1.0.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@~2.0.1"
                             },
                             "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                              "version": "1.0.0",
+                              "from": "isarray@~1.0.0"
+                            },
+                            "process-nextick-args": {
+                              "version": "1.0.7",
+                              "from": "process-nextick-args@~1.0.6"
                             },
                             "string_decoder": {
                               "version": "0.10.31",
                               "from": "string_decoder@~0.10.x",
                               "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                             },
-                            "inherits": {
-                              "version": "2.0.1",
-                              "from": "inherits@~2.0.1",
-                              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                            "util-deprecate": {
+                              "version": "1.0.2",
+                              "from": "util-deprecate@~1.0.1"
                             }
                           }
                         }
                       }
                     },
                     "caseless": {
-                      "version": "0.6.0",
-                      "from": "caseless@~0.6.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz"
+                      "version": "0.11.0",
+                      "from": "caseless@~0.11.0"
+                    },
+                    "extend": {
+                      "version": "3.0.0",
+                      "from": "extend@~3.0.0"
                     },
                     "forever-agent": {
-                      "version": "0.5.2",
-                      "from": "forever-agent@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
-                    },
-                    "qs": {
-                      "version": "1.2.2",
-                      "from": "qs@~1.2.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@~5.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "mime-types": {
-                      "version": "1.0.2",
-                      "from": "mime-types@~1.0.1",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                    },
-                    "node-uuid": {
-                      "version": "1.4.3",
-                      "from": "node-uuid@~1.4.0",
-                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.3.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.4.1",
-                      "from": "tunnel-agent@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.1.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.2.0",
-                      "from": "tough-cookie@>=0.12.0",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.0.tgz"
+                      "version": "0.6.1",
+                      "from": "forever-agent@~0.6.1"
                     },
                     "form-data": {
-                      "version": "0.1.4",
-                      "from": "form-data@~0.1.0",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.4.tgz",
+                      "version": "1.0.1",
+                      "from": "form-data@~1.0.0-rc3",
                       "dependencies": {
-                        "combined-stream": {
-                          "version": "0.0.7",
-                          "from": "combined-stream@~0.0.4",
-                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                        "async": {
+                          "version": "2.1.4",
+                          "from": "async@^2.0.1",
+                          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
                           "dependencies": {
-                            "delayed-stream": {
-                              "version": "0.0.5",
-                              "from": "delayed-stream@0.0.5",
-                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            "lodash": {
+                              "version": "4.17.4",
+                              "from": "lodash@^4.14.0"
                             }
                           }
-                        },
-                        "mime": {
-                          "version": "1.2.11",
-                          "from": "mime@~1.2.11",
-                          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                        },
-                        "async": {
-                          "version": "0.9.2",
-                          "from": "async@~0.9.0",
-                          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
                         }
                       }
                     },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.14",
+                      "from": "mime-types@~2.1.7",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.26.0",
+                          "from": "mime-db@~1.26.0",
+                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+                        }
+                      }
+                    },
+                    "node-uuid": {
+                      "version": "1.4.7",
+                      "from": "node-uuid@~1.4.7",
+                      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+                    },
+                    "qs": {
+                      "version": "5.2.1",
+                      "from": "qs@~5.2.0"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.4.3",
+                      "from": "tunnel-agent@~0.4.1"
+                    },
+                    "tough-cookie": {
+                      "version": "2.2.2",
+                      "from": "tough-cookie@~2.2.0"
+                    },
                     "http-signature": {
-                      "version": "0.10.1",
-                      "from": "http-signature@~0.10.0",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                      "version": "1.1.1",
+                      "from": "http-signature@~1.1.0",
                       "dependencies": {
                         "assert-plus": {
-                          "version": "0.1.5",
-                          "from": "assert-plus@^0.1.5",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                          "version": "0.2.0",
+                          "from": "assert-plus@^0.2.0"
                         },
-                        "asn1": {
-                          "version": "0.1.11",
-                          "from": "asn1@0.1.11",
-                          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                        "jsprim": {
+                          "version": "1.3.1",
+                          "from": "jsprim@^1.2.2",
+                          "dependencies": {
+                            "extsprintf": {
+                              "version": "1.0.2",
+                              "from": "extsprintf@1.0.2",
+                              "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                            },
+                            "json-schema": {
+                              "version": "0.2.3",
+                              "from": "json-schema@0.2.3",
+                              "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                            },
+                            "verror": {
+                              "version": "1.3.6",
+                              "from": "verror@1.3.6",
+                              "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                            }
+                          }
                         },
-                        "ctype": {
-                          "version": "0.5.3",
-                          "from": "ctype@0.5.3",
-                          "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                        "sshpk": {
+                          "version": "1.10.2",
+                          "from": "sshpk@^1.7.0",
+                          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                          "dependencies": {
+                            "asn1": {
+                              "version": "0.2.3",
+                              "from": "asn1@~0.2.3"
+                            },
+                            "assert-plus": {
+                              "version": "1.0.0",
+                              "from": "assert-plus@^1.0.0"
+                            },
+                            "dashdash": {
+                              "version": "1.14.1",
+                              "from": "dashdash@^1.12.0",
+                              "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                            },
+                            "getpass": {
+                              "version": "0.1.6",
+                              "from": "getpass@^0.1.1"
+                            },
+                            "jsbn": {
+                              "version": "0.1.0",
+                              "from": "jsbn@~0.1.0"
+                            },
+                            "tweetnacl": {
+                              "version": "0.14.5",
+                              "from": "tweetnacl@~0.14.0",
+                              "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                            },
+                            "jodid25519": {
+                              "version": "1.0.2",
+                              "from": "jodid25519@^1.0.0"
+                            },
+                            "ecc-jsbn": {
+                              "version": "0.1.1",
+                              "from": "ecc-jsbn@~0.1.1"
+                            },
+                            "bcrypt-pbkdf": {
+                              "version": "1.0.0",
+                              "from": "bcrypt-pbkdf@^1.0.0"
+                            }
+                          }
                         }
                       }
                     },
                     "oauth-sign": {
-                      "version": "0.4.0",
-                      "from": "oauth-sign@~0.4.0",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.4.0.tgz"
+                      "version": "0.8.2",
+                      "from": "oauth-sign@~0.8.0"
                     },
                     "hawk": {
-                      "version": "1.1.1",
-                      "from": "hawk@1.1.1",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+                      "version": "3.1.3",
+                      "from": "hawk@~3.1.0",
                       "dependencies": {
                         "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@0.9.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+                          "version": "2.16.3",
+                          "from": "hoek@2.x.x"
                         },
                         "boom": {
-                          "version": "0.4.2",
-                          "from": "boom@0.4.x",
-                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+                          "version": "2.10.1",
+                          "from": "boom@2.x.x"
                         },
                         "cryptiles": {
-                          "version": "0.2.2",
-                          "from": "cryptiles@0.2.x",
-                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                          "version": "2.0.5",
+                          "from": "cryptiles@2.x.x"
                         },
                         "sntp": {
-                          "version": "0.2.4",
-                          "from": "sntp@0.2.x",
-                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+                          "version": "1.0.9",
+                          "from": "sntp@1.x.x"
                         }
                       }
                     },
                     "aws-sign2": {
-                      "version": "0.5.0",
-                      "from": "aws-sign2@~0.5.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                      "version": "0.6.0",
+                      "from": "aws-sign2@~0.6.0"
                     },
                     "stringstream": {
                       "version": "0.0.5",
                       "from": "stringstream@~0.0.4",
                       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@~1.0.5",
+                      "dependencies": {
+                        "delayed-stream": {
+                          "version": "1.0.0",
+                          "from": "delayed-stream@~1.0.0"
+                        }
+                      }
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@~0.1.2"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@~1.0.0"
+                    },
+                    "har-validator": {
+                      "version": "2.0.6",
+                      "from": "har-validator@~2.0.2",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@^1.1.1",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@^2.2.1"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@^1.0.2"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@^3.0.0",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@^2.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "commander": {
+                          "version": "2.9.0",
+                          "from": "commander@^2.9.0",
+                          "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                          "dependencies": {
+                            "graceful-readlink": {
+                              "version": "1.0.1",
+                              "from": "graceful-readlink@>= 1.0.0",
+                              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                            }
+                          }
+                        },
+                        "is-my-json-valid": {
+                          "version": "2.15.0",
+                          "from": "is-my-json-valid@^2.12.4",
+                          "dependencies": {
+                            "generate-function": {
+                              "version": "2.0.0",
+                              "from": "generate-function@^2.0.0"
+                            },
+                            "generate-object-property": {
+                              "version": "1.2.0",
+                              "from": "generate-object-property@^1.1.0",
+                              "dependencies": {
+                                "is-property": {
+                                  "version": "1.0.2",
+                                  "from": "is-property@^1.0.0"
+                                }
+                              }
+                            },
+                            "jsonpointer": {
+                              "version": "4.0.1",
+                              "from": "jsonpointer@^4.0.0"
+                            },
+                            "xtend": {
+                              "version": "4.0.1",
+                              "from": "xtend@^4.0.0",
+                              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@^2.0.0",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@^2.0.0"
+                            }
+                          }
+                        }
+                      }
                     }
                   }
                 },
                 "request-progress": {
-                  "version": "0.3.1",
-                  "from": "request-progress@0.3.1",
-                  "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-0.3.1.tgz",
+                  "version": "2.0.1",
+                  "from": "request-progress@~2.0.1",
                   "dependencies": {
                     "throttleit": {
-                      "version": "0.0.2",
-                      "from": "throttleit@~0.0.2",
-                      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-0.0.2.tgz"
+                      "version": "1.0.0",
+                      "from": "throttleit@^1.0.0"
                     }
                   }
                 },
                 "which": {
-                  "version": "1.0.9",
-                  "from": "which@~1.0.5",
-                  "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz"
+                  "version": "1.2.12",
+                  "from": "which@~1.2.2",
+                  "dependencies": {
+                    "isexe": {
+                      "version": "1.1.2",
+                      "from": "isexe@^1.1.1"
+                    }
+                  }
                 }
               }
             }
@@ -2067,9 +3993,9 @@
           "resolved": "https://registry.npmjs.org/es5-shim/-/es5-shim-4.0.6.tgz"
         },
         "jasmine-core": {
-          "version": "2.3.4",
+          "version": "2.5.2",
           "from": "jasmine-core@>=2.0.4",
-          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.5.2.tgz"
         }
       }
     },
@@ -2080,45 +4006,54 @@
       "dependencies": {
         "hooker": {
           "version": "0.2.3",
-          "from": "hooker@^0.2.3",
+          "from": "hooker@~0.2.3",
           "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
         },
         "jshint": {
-          "version": "2.8.0",
+          "version": "2.9.4",
           "from": "jshint@^2.6.0",
-          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.8.0.tgz",
+          "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.4.tgz",
           "dependencies": {
             "cli": {
-              "version": "0.6.6",
-              "from": "cli@0.6.x",
-              "resolved": "https://registry.npmjs.org/cli/-/cli-0.6.6.tgz",
+              "version": "1.0.1",
+              "from": "cli@~1.0.0",
+              "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
               "dependencies": {
                 "glob": {
-                  "version": "3.2.11",
-                  "from": "glob@~ 3.2.1",
-                  "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+                  "version": "7.1.1",
+                  "from": "glob@^7.1.1",
                   "dependencies": {
-                    "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@2",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@^1.0.0"
                     },
-                    "minimatch": {
-                      "version": "0.3.0",
-                      "from": "minimatch@0.3",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@^1.0.4",
                       "dependencies": {
-                        "lru-cache": {
-                          "version": "2.7.0",
-                          "from": "lru-cache@2",
-                          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
-                        },
-                        "sigmund": {
-                          "version": "1.0.1",
-                          "from": "sigmund@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@1"
                         }
                       }
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@2"
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@^1.3.0",
+                      "dependencies": {
+                        "wrappy": {
+                          "version": "1.0.2",
+                          "from": "wrappy@1"
+                        }
+                      }
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@^1.0.0"
                     }
                   }
                 }
@@ -2181,14 +4116,13 @@
                   "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
                 },
                 "readable-stream": {
-                  "version": "1.1.13",
+                  "version": "1.1.14",
                   "from": "readable-stream@1.1",
-                  "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                   "dependencies": {
                     "core-util-is": {
-                      "version": "1.0.1",
+                      "version": "1.0.2",
                       "from": "core-util-is@~1.0.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
@@ -2201,9 +4135,8 @@
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
-                      "version": "2.0.1",
-                      "from": "inherits@~2.0.1",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                      "version": "2.0.3",
+                      "from": "inherits@~2.0.1"
                     }
                   }
                 },
@@ -2215,19 +4148,16 @@
               }
             },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@2.0.x",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "3.0.3",
+              "from": "minimatch@~3.0.2",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
+                  "version": "1.1.6",
                   "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                      "version": "0.4.2",
+                      "from": "balanced-match@^0.4.1"
                     },
                     "concat-map": {
                       "version": "0.0.1",
@@ -2263,9 +4193,8 @@
       "resolved": "https://registry.npmjs.org/grunt-contrib-requirejs/-/grunt-contrib-requirejs-0.4.4.tgz",
       "dependencies": {
         "requirejs": {
-          "version": "2.1.20",
-          "from": "requirejs@~2.1.0",
-          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.1.20.tgz"
+          "version": "2.1.22",
+          "from": "requirejs@~2.1.0"
         }
       }
     },
@@ -2312,9 +4241,8 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.7.0",
-                      "from": "lru-cache@2",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.0.tgz"
+                      "version": "2.7.3",
+                      "from": "lru-cache@2"
                     },
                     "sigmund": {
                       "version": "1.0.1",
@@ -2353,9 +4281,8 @@
                   "resolved": "https://registry.npmjs.org/nopt/-/nopt-2.0.0.tgz",
                   "dependencies": {
                     "abbrev": {
-                      "version": "1.0.7",
-                      "from": "abbrev@1",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.7.tgz"
+                      "version": "1.0.9",
+                      "from": "abbrev@1"
                     }
                   }
                 }
@@ -2381,30 +4308,32 @@
       }
     },
     "grunt-saucelabs": {
-      "version": "8.6.2",
+      "version": "9.0.0",
       "from": "grunt-saucelabs@*",
-      "resolved": "https://registry.npmjs.org/grunt-saucelabs/-/grunt-saucelabs-8.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/grunt-saucelabs/-/grunt-saucelabs-9.0.0.tgz",
       "dependencies": {
         "colors": {
-          "version": "1.0.3",
-          "from": "colors@~1.0.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+          "version": "1.1.2",
+          "from": "colors@~1.1.2"
         },
         "lodash": {
-          "version": "3.7.0",
-          "from": "lodash@~3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz"
+          "version": "4.13.1",
+          "from": "lodash@~4.13.1"
         },
         "q": {
-          "version": "1.3.0",
-          "from": "q@~1.3.0",
-          "resolved": "https://registry.npmjs.org/q/-/q-1.3.0.tgz"
+          "version": "1.4.1",
+          "from": "q@~1.4.1",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
         },
         "requestretry": {
-          "version": "1.2.2",
-          "from": "requestretry@~1.2.2",
-          "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
+          "version": "1.9.1",
+          "from": "requestretry@~1.9.0",
+          "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.9.1.tgz",
           "dependencies": {
+            "extend": {
+              "version": "3.0.0",
+              "from": "extend@3"
+            },
             "fg-lodash": {
               "version": "0.0.2",
               "from": "fg-lodash@0.0.2",
@@ -2423,387 +4352,621 @@
               }
             },
             "request": {
-              "version": "2.51.0",
-              "from": "request@2.51.x",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+              "version": "2.79.0",
+              "from": "request@^2.74.x",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "dependencies": {
-                "bl": {
-                  "version": "0.9.4",
-                  "from": "bl@~0.9.0",
-                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
-                  "dependencies": {
-                    "readable-stream": {
-                      "version": "1.0.33",
-                      "from": "readable-stream@~1.0.26",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@~1.0.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "0.0.1",
-                          "from": "isarray@0.0.1",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "0.10.31",
-                          "from": "string_decoder@~0.10.x",
-                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                        },
-                        "inherits": {
-                          "version": "2.0.1",
-                          "from": "inherits@~2.0.1",
-                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0"
+                },
+                "aws4": {
+                  "version": "1.5.0",
+                  "from": "aws4@^1.2.1"
                 },
                 "caseless": {
-                  "version": "0.8.0",
-                  "from": "caseless@~0.8.0",
-                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@~1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0"
+                    }
+                  }
                 },
                 "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                  "version": "0.6.1",
+                  "from": "forever-agent@~0.6.1"
                 },
                 "form-data": {
-                  "version": "0.2.0",
-                  "from": "form-data@~0.2.0",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+                  "version": "2.1.2",
+                  "from": "form-data@~2.1.1",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
                   "dependencies": {
-                    "async": {
-                      "version": "0.9.2",
-                      "from": "async@~0.9.0",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.0.14",
-                      "from": "mime-types@~2.0.3",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@^0.4.0"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "from": "har-validator@~2.0.6",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@^1.1.1",
                       "dependencies": {
-                        "mime-db": {
-                          "version": "1.12.0",
-                          "from": "mime-db@~1.12.0",
-                          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@^2.2.1"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@^1.0.2"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@^3.0.0",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@^2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@^2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>= 1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "from": "is-my-json-valid@^2.12.4",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@^2.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@^1.1.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@^1.0.0"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.1",
+                          "from": "jsonpointer@^4.0.0"
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@^2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@^2.0.0"
                         }
                       }
                     }
                   }
+                },
+                "hawk": {
+                  "version": "3.1.3",
+                  "from": "hawk@~3.1.3",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x"
+                    }
+                  }
+                },
+                "http-signature": {
+                  "version": "1.1.1",
+                  "from": "http-signature@~1.1.0",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@^0.2.0"
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "from": "jsprim@^1.2.2",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "from": "extsprintf@1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "from": "json-schema@0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "from": "verror@1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.10.2",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "from": "asn1@~0.2.3"
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@^1.0.0"
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "from": "dashdash@^1.12.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "from": "getpass@^0.1.1"
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "from": "jsbn@~0.1.0"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.5",
+                          "from": "tweetnacl@~0.14.0",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@^1.0.0"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@~0.1.1"
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "from": "bcrypt-pbkdf@^1.0.0"
+                        }
+                      }
+                    }
+                  }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@~1.0.0"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.2"
                 },
                 "json-stringify-safe": {
                   "version": "5.0.1",
-                  "from": "json-stringify-safe@~5.0.0",
+                  "from": "json-stringify-safe@~5.0.1",
                   "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
                 },
                 "mime-types": {
-                  "version": "1.0.2",
-                  "from": "mime-types@~1.0.1",
-                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                },
-                "qs": {
-                  "version": "2.3.3",
-                  "from": "qs@~2.3.1",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
-                },
-                "tunnel-agent": {
-                  "version": "0.4.2",
-                  "from": "tunnel-agent@~0.4.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.2.tgz"
-                },
-                "tough-cookie": {
-                  "version": "2.2.1",
-                  "from": "tough-cookie@>=0.12.0",
-                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.2.1.tgz"
-                },
-                "http-signature": {
-                  "version": "0.10.1",
-                  "from": "http-signature@~0.10.0",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "version": "2.1.14",
+                  "from": "mime-types@~2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.5",
-                      "from": "assert-plus@^0.1.5",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
-                    },
-                    "ctype": {
-                      "version": "0.5.3",
-                      "from": "ctype@0.5.3",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    "mime-db": {
+                      "version": "1.26.0",
+                      "from": "mime-db@~1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
                     }
                   }
                 },
                 "oauth-sign": {
-                  "version": "0.5.0",
-                  "from": "oauth-sign@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+                  "version": "0.8.2",
+                  "from": "oauth-sign@~0.8.1"
                 },
-                "hawk": {
-                  "version": "1.1.1",
-                  "from": "hawk@1.1.1",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-                  "dependencies": {
-                    "hoek": {
-                      "version": "0.9.1",
-                      "from": "hoek@0.9.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                    },
-                    "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
-                    }
-                  }
-                },
-                "aws-sign2": {
-                  "version": "0.5.0",
-                  "from": "aws-sign2@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                "qs": {
+                  "version": "6.3.0",
+                  "from": "qs@~6.3.0"
                 },
                 "stringstream": {
                   "version": "0.0.5",
                   "from": "stringstream@~0.0.4",
                   "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
                 },
-                "combined-stream": {
-                  "version": "0.0.7",
-                  "from": "combined-stream@~0.0.5",
-                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "from": "tough-cookie@~2.3.0",
                   "dependencies": {
-                    "delayed-stream": {
-                      "version": "0.0.5",
-                      "from": "delayed-stream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@^1.4.1"
                     }
                   }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "from": "tunnel-agent@~0.4.1"
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "from": "uuid@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
                 }
               }
+            },
+            "when": {
+              "version": "3.7.7",
+              "from": "when@~3.7.5",
+              "resolved": "https://registry.npmjs.org/when/-/when-3.7.7.tgz"
             }
           }
         },
         "sauce-tunnel": {
-          "version": "2.3.0",
-          "from": "sauce-tunnel@~2.3.0",
-          "resolved": "https://registry.npmjs.org/sauce-tunnel/-/sauce-tunnel-2.3.0.tgz",
+          "version": "2.5.0",
+          "from": "sauce-tunnel@~2.5.0",
+          "resolved": "https://registry.npmjs.org/sauce-tunnel/-/sauce-tunnel-2.5.0.tgz",
           "dependencies": {
             "chalk": {
-              "version": "1.0.0",
-              "from": "chalk@~1.0.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+              "version": "1.1.3",
+              "from": "chalk@^1.1.3",
               "dependencies": {
                 "ansi-styles": {
-                  "version": "2.1.0",
-                  "from": "ansi-styles@^2.0.1",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.1.0.tgz"
+                  "version": "2.2.1",
+                  "from": "ansi-styles@^2.2.1"
                 },
                 "escape-string-regexp": {
-                  "version": "1.0.4",
-                  "from": "escape-string-regexp@^1.0.2",
-                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.4.tgz"
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@^1.0.2"
                 },
                 "has-ansi": {
-                  "version": "1.0.3",
-                  "from": "has-ansi@^1.0.3",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                  "version": "2.0.0",
+                  "from": "has-ansi@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
-                    },
-                    "get-stdin": {
-                      "version": "4.0.1",
-                      "from": "get-stdin@^4.0.1",
-                      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                      "version": "2.1.1",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
-                  "version": "2.0.1",
-                  "from": "strip-ansi@^2.0.1",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                  "version": "3.0.1",
+                  "from": "strip-ansi@^3.0.0",
                   "dependencies": {
                     "ansi-regex": {
-                      "version": "1.1.1",
-                      "from": "ansi-regex@^1.1.0",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                      "version": "2.1.1",
+                      "from": "ansi-regex@^2.0.0",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
-                  "version": "1.3.1",
-                  "from": "supports-color@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                  "version": "2.0.0",
+                  "from": "supports-color@^2.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
                 }
               }
             },
             "request": {
-              "version": "2.21.0",
-              "from": "request@~2.21.0",
-              "resolved": "https://registry.npmjs.org/request/-/request-2.21.0.tgz",
+              "version": "2.79.0",
+              "from": "request@^2.72.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.79.0.tgz",
               "dependencies": {
-                "qs": {
-                  "version": "0.6.6",
-                  "from": "qs@~0.6.0",
-                  "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz"
+                "aws-sign2": {
+                  "version": "0.6.0",
+                  "from": "aws-sign2@~0.6.0"
                 },
-                "json-stringify-safe": {
-                  "version": "4.0.0",
-                  "from": "json-stringify-safe@~4.0.0",
-                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-4.0.0.tgz"
+                "aws4": {
+                  "version": "1.5.0",
+                  "from": "aws4@^1.2.1"
+                },
+                "caseless": {
+                  "version": "0.11.0",
+                  "from": "caseless@~0.11.0"
+                },
+                "combined-stream": {
+                  "version": "1.0.5",
+                  "from": "combined-stream@~1.0.5",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@~1.0.0"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@~3.0.0"
                 },
                 "forever-agent": {
-                  "version": "0.5.2",
-                  "from": "forever-agent@~0.5.0",
-                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+                  "version": "0.6.1",
+                  "from": "forever-agent@~0.6.1"
                 },
-                "tunnel-agent": {
-                  "version": "0.3.0",
-                  "from": "tunnel-agent@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.3.0.tgz"
-                },
-                "http-signature": {
-                  "version": "0.9.11",
-                  "from": "http-signature@~0.9.11",
-                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.9.11.tgz",
+                "form-data": {
+                  "version": "2.1.2",
+                  "from": "form-data@~2.1.1",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
                   "dependencies": {
-                    "assert-plus": {
-                      "version": "0.1.2",
-                      "from": "assert-plus@0.1.2",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.2.tgz"
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@^0.4.0"
+                    }
+                  }
+                },
+                "har-validator": {
+                  "version": "2.0.6",
+                  "from": "har-validator@~2.0.6",
+                  "dependencies": {
+                    "commander": {
+                      "version": "2.9.0",
+                      "from": "commander@^2.9.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>= 1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
                     },
-                    "asn1": {
-                      "version": "0.1.11",
-                      "from": "asn1@0.1.11",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    "is-my-json-valid": {
+                      "version": "2.15.0",
+                      "from": "is-my-json-valid@^2.12.4",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@^2.0.0"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@^1.1.0",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@^1.0.0"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "4.0.1",
+                          "from": "jsonpointer@^4.0.0"
+                        },
+                        "xtend": {
+                          "version": "4.0.1",
+                          "from": "xtend@^4.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                        }
+                      }
                     },
-                    "ctype": {
-                      "version": "0.5.2",
-                      "from": "ctype@0.5.2",
-                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.2.tgz"
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@^2.0.0",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@^2.0.0"
+                        }
+                      }
                     }
                   }
                 },
                 "hawk": {
-                  "version": "0.13.1",
-                  "from": "hawk@~0.13.0",
-                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.13.1.tgz",
+                  "version": "3.1.3",
+                  "from": "hawk@~3.1.3",
                   "dependencies": {
                     "hoek": {
-                      "version": "0.8.5",
-                      "from": "hoek@0.8.x",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.8.5.tgz"
+                      "version": "2.16.3",
+                      "from": "hoek@2.x.x"
                     },
                     "boom": {
-                      "version": "0.4.2",
-                      "from": "boom@0.4.x",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@0.9.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                        }
-                      }
+                      "version": "2.10.1",
+                      "from": "boom@2.x.x"
                     },
                     "cryptiles": {
-                      "version": "0.2.2",
-                      "from": "cryptiles@0.2.x",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.x.x"
                     },
                     "sntp": {
-                      "version": "0.2.4",
-                      "from": "sntp@0.2.x",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-                      "dependencies": {
-                        "hoek": {
-                          "version": "0.9.1",
-                          "from": "hoek@0.9.x",
-                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
-                        }
-                      }
+                      "version": "1.0.9",
+                      "from": "sntp@1.x.x"
                     }
                   }
                 },
-                "aws-sign": {
-                  "version": "0.3.0",
-                  "from": "aws-sign@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.3.0.tgz"
-                },
-                "oauth-sign": {
-                  "version": "0.3.0",
-                  "from": "oauth-sign@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.3.0.tgz"
-                },
-                "cookie-jar": {
-                  "version": "0.3.0",
-                  "from": "cookie-jar@~0.3.0",
-                  "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.3.0.tgz"
-                },
-                "node-uuid": {
-                  "version": "1.4.7",
-                  "from": "node-uuid@~1.4.0",
-                  "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-                },
-                "mime": {
-                  "version": "1.2.11",
-                  "from": "mime@~1.2.9",
-                  "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
-                },
-                "form-data": {
-                  "version": "0.0.8",
-                  "from": "form-data@0.0.8",
-                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.8.tgz",
+                "http-signature": {
+                  "version": "1.1.1",
+                  "from": "http-signature@~1.1.0",
                   "dependencies": {
-                    "combined-stream": {
-                      "version": "0.0.7",
-                      "from": "combined-stream@~0.0.4",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@^0.2.0"
+                    },
+                    "jsprim": {
+                      "version": "1.3.1",
+                      "from": "jsprim@^1.2.2",
                       "dependencies": {
-                        "delayed-stream": {
-                          "version": "0.0.5",
-                          "from": "delayed-stream@0.0.5",
-                          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                        "extsprintf": {
+                          "version": "1.0.2",
+                          "from": "extsprintf@1.0.2",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                        },
+                        "json-schema": {
+                          "version": "0.2.3",
+                          "from": "json-schema@0.2.3",
+                          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                        },
+                        "verror": {
+                          "version": "1.3.6",
+                          "from": "verror@1.3.6",
+                          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
                         }
                       }
                     },
-                    "async": {
-                      "version": "0.2.10",
-                      "from": "async@~0.2.7",
-                      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                    "sshpk": {
+                      "version": "1.10.2",
+                      "from": "sshpk@^1.7.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.2.tgz",
+                      "dependencies": {
+                        "asn1": {
+                          "version": "0.2.3",
+                          "from": "asn1@~0.2.3"
+                        },
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@^1.0.0"
+                        },
+                        "dashdash": {
+                          "version": "1.14.1",
+                          "from": "dashdash@^1.12.0",
+                          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                        },
+                        "getpass": {
+                          "version": "0.1.6",
+                          "from": "getpass@^0.1.1"
+                        },
+                        "jsbn": {
+                          "version": "0.1.0",
+                          "from": "jsbn@~0.1.0"
+                        },
+                        "tweetnacl": {
+                          "version": "0.14.5",
+                          "from": "tweetnacl@~0.14.0",
+                          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                        },
+                        "jodid25519": {
+                          "version": "1.0.2",
+                          "from": "jodid25519@^1.0.0"
+                        },
+                        "ecc-jsbn": {
+                          "version": "0.1.1",
+                          "from": "ecc-jsbn@~0.1.1"
+                        },
+                        "bcrypt-pbkdf": {
+                          "version": "1.0.0",
+                          "from": "bcrypt-pbkdf@^1.0.0"
+                        }
+                      }
                     }
                   }
+                },
+                "is-typedarray": {
+                  "version": "1.0.0",
+                  "from": "is-typedarray@~1.0.0"
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@~0.1.2"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@~5.0.1",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.14",
+                  "from": "mime-types@~2.1.7",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.26.0",
+                      "from": "mime-db@~1.26.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.8.2",
+                  "from": "oauth-sign@~0.8.1"
+                },
+                "qs": {
+                  "version": "6.3.0",
+                  "from": "qs@~6.3.0"
+                },
+                "stringstream": {
+                  "version": "0.0.5",
+                  "from": "stringstream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                },
+                "tough-cookie": {
+                  "version": "2.3.2",
+                  "from": "tough-cookie@~2.3.0",
+                  "dependencies": {
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@^1.4.1"
+                    }
+                  }
+                },
+                "tunnel-agent": {
+                  "version": "0.4.3",
+                  "from": "tunnel-agent@~0.4.1"
+                },
+                "uuid": {
+                  "version": "3.0.1",
+                  "from": "uuid@^3.0.0",
+                  "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
                 }
               }
             },
             "split": {
-              "version": "0.3.3",
-              "from": "split@~0.3.2",
-              "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+              "version": "1.0.0",
+              "from": "split@^1.0.0",
+              "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz",
               "dependencies": {
                 "through": {
                   "version": "2.3.8",
@@ -2815,9 +4978,45 @@
           }
         },
         "saucelabs": {
-          "version": "0.1.1",
-          "from": "saucelabs@~0.1.1",
-          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-0.1.1.tgz"
+          "version": "1.2.0",
+          "from": "saucelabs@~1.2.0",
+          "resolved": "https://registry.npmjs.org/saucelabs/-/saucelabs-1.2.0.tgz",
+          "dependencies": {
+            "https-proxy-agent": {
+              "version": "1.0.0",
+              "from": "https-proxy-agent@^1.0.0",
+              "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-1.0.0.tgz",
+              "dependencies": {
+                "agent-base": {
+                  "version": "2.0.1",
+                  "from": "agent-base@2",
+                  "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-2.0.1.tgz",
+                  "dependencies": {
+                    "semver": {
+                      "version": "5.0.3",
+                      "from": "semver@~5.0.1",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz"
+                    }
+                  }
+                },
+                "debug": {
+                  "version": "2.6.0",
+                  "from": "debug@2",
+                  "dependencies": {
+                    "ms": {
+                      "version": "0.7.2",
+                      "from": "ms@0.7.2",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+                    }
+                  }
+                },
+                "extend": {
+                  "version": "3.0.0",
+                  "from": "extend@3"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -2842,21 +5041,18 @@
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
               "dependencies": {
                 "inflight": {
-                  "version": "1.0.4",
+                  "version": "1.0.6",
                   "from": "inflight@^1.0.4",
-                  "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@1"
                     }
                   }
                 },
                 "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                  "version": "2.0.3",
+                  "from": "inherits@2"
                 },
                 "minimatch": {
                   "version": "2.0.10",
@@ -2864,14 +5060,12 @@
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
                   "dependencies": {
                     "brace-expansion": {
-                      "version": "1.1.1",
+                      "version": "1.1.6",
                       "from": "brace-expansion@^1.0.0",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                       "dependencies": {
                         "balanced-match": {
-                          "version": "0.2.1",
-                          "from": "balanced-match@^0.2.0",
-                          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                          "version": "0.4.2",
+                          "from": "balanced-match@^0.4.1"
                         },
                         "concat-map": {
                           "version": "0.0.1",
@@ -2883,14 +5077,12 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.2",
+                  "version": "1.4.0",
                   "from": "once@^1.3.0",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
-                      "version": "1.0.1",
-                      "from": "wrappy@1",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                      "version": "1.0.2",
+                      "from": "wrappy@1"
                     }
                   }
                 }
@@ -2899,9 +5091,8 @@
           }
         },
         "multimatch": {
-          "version": "2.0.0",
+          "version": "2.1.0",
           "from": "multimatch@^2.0.0",
-          "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.0.0.tgz",
           "dependencies": {
             "array-differ": {
               "version": "1.0.0",
@@ -2909,31 +5100,30 @@
               "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz"
             },
             "array-union": {
-              "version": "1.0.1",
+              "version": "1.0.2",
               "from": "array-union@^1.0.1",
-              "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.1.tgz",
               "dependencies": {
                 "array-uniq": {
-                  "version": "1.0.2",
-                  "from": "array-uniq@^1.0.1",
-                  "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.2.tgz"
+                  "version": "1.0.3",
+                  "from": "array-uniq@^1.0.1"
                 }
               }
             },
+            "arrify": {
+              "version": "1.0.1",
+              "from": "arrify@^1.0.0"
+            },
             "minimatch": {
-              "version": "2.0.10",
-              "from": "minimatch@^2.0.1",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+              "version": "3.0.3",
+              "from": "minimatch@^3.0.0",
               "dependencies": {
                 "brace-expansion": {
-                  "version": "1.1.1",
+                  "version": "1.1.6",
                   "from": "brace-expansion@^1.0.0",
-                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.1.tgz",
                   "dependencies": {
                     "balanced-match": {
-                      "version": "0.2.1",
-                      "from": "balanced-match@^0.2.0",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.1.tgz"
+                      "version": "0.4.2",
+                      "from": "balanced-match@^0.4.1"
                     },
                     "concat-map": {
                       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -5,16 +5,19 @@
   "author": "Nutonian, Inc.",
   "repository": "https://bitbucket.org/nutonian/nugget",
   "devDependencies": {
+    "babel-plugin-add-module-exports": "0.2.1",
+    "babel-polyfill": "6.22.0",
+    "babel-preset-es2015": "6.22.0",
     "grunt": "0.4.5",
-    "grunt-babel": "5.0.1",
+    "grunt-babel": "6.0.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-connect": "0.9.0",
     "grunt-contrib-jasmine": "0.8.2",
     "grunt-contrib-jshint": "0.11.1",
     "grunt-contrib-requirejs": "0.4.4",
     "grunt-contrib-watch": "0.6.1",
+    "grunt-saucelabs": "9.0.0",
     "grunt-template-jasmine-requirejs": "0.2.2",
-    "load-grunt-tasks": "3.1.0",
-    "grunt-saucelabs": "*"
+    "load-grunt-tasks": "3.1.0"
   }
 }


### PR DESCRIPTION
This updates us to the latest versions of Babel and Almond (the lib we use to wrap Nugget as an AMD module). Babel has gotten a little bit stricter about a few things re: `super` which required a few small updates. I'll call those out inline.