### PR TITLE
Allow sparse data series in line and scatter graphs

### DIFF
--- a/example/sparse_line.html
+++ b/example/sparse_line.html
@@ -1,0 +1,65 @@
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Nugget.js Graphing Library</title>
+    <script src="/dependencies/d3.js"></script>
+    <script src="js/require.min.js"></script>
+    <link type="text/css" href="/css/nugget.css" rel="stylesheet">
+    <link type="text/css" href="example.css" rel="stylesheet">
+</head>
+<body>
+    <h1>Nugget</h1>
+    <h4>Sparse Line Graph Example</h4>
+    <button id="update_data" type="button">New data</button>
+    <div class="svg_container" style="height: 400px; width: 600px; margin-top: 20px;">
+        <svg id="line_graph_nugget"></svg>
+    </div>
+    <script>
+        require.config({ baseUrl: '/build' });
+
+        function generateData(length) {
+            var data = Array.apply(null, Array(length)).map(function (_, i) {
+                return {
+                    x_value: (Math.random() > 0.8) ? null : i,
+                    y_value: (Math.random() > 0.65) ? null : Math.floor(Math.random() * 10)
+                };
+            });
+            console.log('-- generated --');
+            data.forEach(function(point) {
+                console.log(point.x_value, point.y_value);
+            });
+            return data;
+        }
+
+        require(['Nugget'], function (Nugget) {
+            var data = generateData(50);
+
+            var dataSeries = new Nugget.SparseNumericalDataSeries(data);
+
+            document.getElementById('update_data').addEventListener('click', function() {
+                dataSeries.setData(generateData(50));
+            });
+
+            var chart = new Nugget.Chart({
+                axisLabels: { x_value: 'x', y_value: 'y' },
+                margins:  { left: 20 },
+                legend: true,
+                resizeHeight: true,
+                resizeWidth: true
+            });
+
+            var line = new Nugget.LineGraph({
+                dataSeries: dataSeries,
+                color: 'green',
+                legendLabel: 'data',
+                showErrorBars: true
+            });
+
+            chart.add(line);
+            chart.addGuide(Nugget.Chart.GuideTypes.YYComparison);
+
+            chart.appendTo('#line_graph_nugget');
+        });
+    </script>
+</body>
+</html>

--- a/lib/Nugget.js
+++ b/lib/Nugget.js
@@ -9,6 +9,7 @@ import BoxPlotDataSeries from './models/BoxPlotDataSeries';
 import DataSeries from './models/DataSeries';
 import NumericalDataSeries from './models/NumericalDataSeries';
 import OrdinalDataSeries from './models/OrdinalDataSeries';
+import SparseNumericalDataSeries from './models/SparseNumericalDataSeries';
 
 import Chart from './presenter/Chart';
 
@@ -24,28 +25,29 @@ import TrendLine from './views/TrendLine';
 import AreaGraph from './views/AreaGraph';
 
 export default {
-    Events                : Events,
-    Utils                 : Utils,
-    Config                : Config,
+    Events                    : Events,
+    Utils                     : Utils,
+    Config                    : Config,
 
-    Axes                  : Axes,
-    AggregateDataRange    : AggregateDataRange,
-    BinnedMeanDataSeries  : BinnedMeanDataSeries,
-    BoxPlotDataSeries     : BoxPlotDataSeries,
-    DataSeries            : DataSeries,
-    NumericalDataSeries   : NumericalDataSeries,
-    OrdinalDataSeries     : OrdinalDataSeries,
+    Axes                      : Axes,
+    AggregateDataRange        : AggregateDataRange,
+    BinnedMeanDataSeries      : BinnedMeanDataSeries,
+    BoxPlotDataSeries         : BoxPlotDataSeries,
+    DataSeries                : DataSeries,
+    NumericalDataSeries       : NumericalDataSeries,
+    OrdinalDataSeries         : OrdinalDataSeries,
+    SparseNumericalDataSeries : SparseNumericalDataSeries,
 
-    Chart                 : Chart,
-    Graph                 : Graph,
+    Chart                     : Chart,
+    Graph                     : Graph,
 
-    BarGraph              : BarGraph,
-    BinnedMeanGraph       : BinnedMeanGraph,
-    BoxPlot               : BoxPlot,
-    Histogram             : Histogram,
-    LegendView            : LegendView,
-    LineGraph             : LineGraph,
-    ScatterGraph          : ScatterGraph,
-    TrendLine             : TrendLine,
-    AreaGraph             : AreaGraph
+    BarGraph                  : BarGraph,
+    BinnedMeanGraph           : BinnedMeanGraph,
+    BoxPlot                   : BoxPlot,
+    Histogram                 : Histogram,
+    LegendView                : LegendView,
+    LineGraph                 : LineGraph,
+    ScatterGraph              : ScatterGraph,
+    TrendLine                 : TrendLine,
+    AreaGraph                 : AreaGraph
 };

--- a/lib/models/SparseNumericalDataSeries.js
+++ b/lib/models/SparseNumericalDataSeries.js
@@ -1,0 +1,19 @@
+import NumericalDataSeries from './NumericalDataSeries';
+
+const NUMERIC_KEYS = ['x_min', 'x_value', 'x_max', 'y_min', 'y_value', 'y_max'];
+
+// Numerical data series with potentially missing values.
+class SparseNumericalDataSeries extends NumericalDataSeries {
+
+    _validate(data) {
+        return data.every(point => (
+            // all points must be objects
+            (typeof point === 'object') &&
+
+            // relevant keys must be numeric if defined and not null
+            NUMERIC_KEYS.every(key => ((point[key] == null) || (typeof point[key] === 'number')))
+        ));
+    }
+}
+
+export default SparseNumericalDataSeries;

--- a/lib/utils/Utils.js
+++ b/lib/utils/Utils.js
@@ -69,6 +69,41 @@ var Utils = {
             }
         }
         return currentClosestElement;
+    },
+
+    /**
+     * Divide a list of data points into multiple lists, splitting on points where a value is
+     * missing (null or undefined) for one or more specific keys.
+     *
+     * @param {Object[]} data - List of data points.
+     * @param {string[]} keys - Keys to check for missing values.
+     *
+     * This is used by the line graph to plot multiple disconnected line segments for a data
+     * series that contains data points with missing x or y values.
+     *
+     * @example
+     * const data = [ {x:1,y:1}, {x:2,y:2}, {x:3,y:null}, {x:4,y:4}]
+     * splitOnMissingValues(data)
+     * // [ [{x:1,y:1}, {x:2,y:2}],
+     * //   [{x:4,y:4}] ]
+     */
+    splitOnMissingValues: function(data, keys) {
+        const segments = [];
+        let currentSegment = [];
+        data.forEach((dataPoint, index) => {
+            if (keys.map(key => dataPoint[key]).some(value => (value === null))) {
+                if (currentSegment.length) {
+                    segments.push(currentSegment);
+                    currentSegment = [];
+                }
+            } else {
+                currentSegment.push(dataPoint);
+            }
+        });
+        if (currentSegment.length) {
+            segments.push(currentSegment);
+        }
+        return segments;
     }
 
 };

--- a/lib/views/LineGraph.js
+++ b/lib/views/LineGraph.js
@@ -1,4 +1,5 @@
 import Graph from '../views/Graph';
+import Utils from '../utils/Utils';
 
 class LineGraph extends Graph {
     constructor(options) {
@@ -25,25 +26,41 @@ class LineGraph extends Graph {
             .y(d => this.yRange(d.y_value))
             .interpolate(this.interpolate);
 
-        var line = this.d3Svg.selectAll('path.line')
-                    .data([this.dataSeries.data]);
+        // Plot multiple line segments if the data series contains missing values.
+        // NumericalDataSeries does not allow this case, but SparseNumericalDataSeries does.
+        var data = Utils.splitOnMissingValues(this.dataSeries.data, ['x_value', 'y_value']);
 
-        line.enter().append('path')
-                    .attr('stroke-width', 2)
-                    .attr('class', 'line')
-                    .attr('fill', 'none')
-                    .attr('stroke', this.color);
+        var multiPointSegments = data.filter(d => d.length > 1);
+        var singlePointSegments = Array.prototype.concat.apply([], data.filter(d => d.length === 1));
 
-        line.call(this._applyInserts.bind(this));
+        var lines = this.d3Svg.selectAll('path.line').data(multiPointSegments);
 
-        if (shouldAnimate) {
-            line.transition()
-                .attr('d', lineFunction);
-        } else {
-            line.attr('d', lineFunction);
-        }
+        lines.enter().append('path')
+            .attr('stroke-width', 2)
+            .attr('class', 'line')
+            .attr('fill', 'none')
+            .attr('stroke', this.color);
 
-        line.exit().remove();
+        lines.call(this._applyInserts.bind(this));
+
+        (shouldAnimate ? lines.transition() : lines).attr('d', lineFunction);
+
+        lines.exit().remove();
+
+        var points = this.d3Svg.selectAll('circle.line').data(singlePointSegments);
+
+        points.enter().append('circle')
+            .attr('class', 'line')
+            .attr('fill', this.color)
+            .attr('r', 2);
+
+        points.call(this._applyInserts.bind(this));
+
+        (shouldAnimate ? points.transition() : points)
+            .attr('cx', d => this.xRange(d.x_value))
+            .attr('cy', d => this.yRange(d.y_value));
+
+        points.exit().remove();
 
         this.legendData.setData(this._createLegendData());
     }
@@ -51,7 +68,7 @@ class LineGraph extends Graph {
     // for a given x value, draws a guide line to the y axis (with y value in a box)
     drawYGuide(xValue, guideEl, chart) {
 
-        var point = this.dataSeries.data.find(p => p.x_value === xValue);
+        var point = this.dataSeries.data.find(p => (p.x_value === xValue && p.y_value !== null));
 
         var circleData = [];
         if (point) {

--- a/lib/views/ScatterGraph.js
+++ b/lib/views/ScatterGraph.js
@@ -15,8 +15,9 @@ class ScatterGraph extends Graph {
 
     draw(shouldAnimate) {
 
-        var circles = this.circles = this.d3Svg.selectAll('circle')
-                    .data(this.dataSeries.data);
+        var pointData = this.dataSeries.data.filter(d => !(d.x_value == null || d.y_value == null));
+
+        var circles = this.circles = this.d3Svg.selectAll('circle').data(pointData);
 
         // for new points, add circles
         circles.enter()
@@ -39,8 +40,9 @@ class ScatterGraph extends Graph {
         circles.exit().remove();
 
         if (this.showErrorBars) {
-            var errorBars = this.errorBars = this.d3Svg.selectAll('.error_bar')
-                .data(this.dataSeries.data);
+            var errorBarData = this.dataSeries.data.filter(d => !(d.x_value == null || d.y_min == null || d.y_max == null));
+
+            var errorBars = this.errorBars = this.d3Svg.selectAll('.error_bar').data(errorBarData);
 
             var errorBarEnterGroup = errorBars.enter()
                 .append('g')
@@ -57,7 +59,9 @@ class ScatterGraph extends Graph {
             errorBarEnterGroup.append('line')
                 .attr('class', 'error_bar-bottom_cap');
 
-            errorBars.select('.error_bar-line')
+            var update = shouldAnimate ? errorBars.transition() : errorBars;
+
+            update.select('.error_bar-line')
                 .attr('x1', d => this.xRange(d.x_value))
                 .attr('x2', d => this.xRange(d.x_value))
                 .attr('y1', d => this.yRange(d.y_min))
@@ -65,13 +69,13 @@ class ScatterGraph extends Graph {
 
             var capSize = 6;
 
-            errorBars.select('.error_bar-top_cap')
+            update.select('.error_bar-top_cap')
                 .attr('x1', d => this.xRange(d.x_value) - capSize)
                 .attr('x2', d => this.xRange(d.x_value) + capSize) // + 2 to make line appear evenly centered
                 .attr('y1', d => this.yRange(d.y_max))
                 .attr('y2', d => this.yRange(d.y_max));
 
-            errorBars.select('.error_bar-bottom_cap')
+            update.select('.error_bar-bottom_cap')
                 .attr('x1', d => this.xRange(d.x_value) - capSize)
                 .attr('x2', d => this.xRange(d.x_value) + capSize) // + 2 to make line appear evenly centered
                 .attr('y1', d => this.yRange(d.y_min))

--- a/test/models/SparseNumericalDataSeries.spec.js
+++ b/test/models/SparseNumericalDataSeries.spec.js
@@ -1,0 +1,46 @@
+define([
+    'Nugget',
+    '../../../dependencies/d3'
+],
+function (
+    Nugget,
+    d3
+) {
+
+    describe('SparseNumericalDataSeries', function() {
+
+        describe('axes', function() {
+            it('should allow overriding default x axis type', function() {
+                var dataSeries = new Nugget.SparseNumericalDataSeries([], {
+                    xAxisType: Nugget.Axes.AXIS_TYPES.DATETIME
+                });
+                expect(dataSeries.xAxisType).toEqual(Nugget.Axes.AXIS_TYPES.DATETIME);
+            });
+
+            it('should allow overriding default y axis type', function() {
+                var dataSeries = new Nugget.SparseNumericalDataSeries([], {
+                    yAxisType: Nugget.Axes.AXIS_TYPES.DATETIME
+                });
+                expect(dataSeries.yAxisType).toEqual(Nugget.Axes.AXIS_TYPES.DATETIME);
+            });
+        });
+
+        it('should validate data', function() {
+            var dataSeries = new Nugget.SparseNumericalDataSeries();
+
+            expect(function() { dataSeries.setData([1, 2, 3]); }).toThrow();
+            expect(function() { dataSeries.setData([{ x_value: '1', y_value: '2' }]); }).toThrow();
+
+            // positive cases
+            expect(function() { dataSeries.setData([{ x_value: 1, y_value: 2 }]); }).not.toThrow();
+            expect(function() { dataSeries.setData([
+                { x_value: 1,    y_value: null },
+                { x_value: null, y_value: 2 }
+            ]); }).not.toThrow();
+            expect(function() { dataSeries.setData([
+                { x_value: 1, x_min: 0, x_max: 3, y_value: 2, y_min: 1, y_max: 3 },
+                { x_value: 1, x_min: 1, x_max: 3, y_value: 2, y_min: 0, y_max: 3 }
+            ]); }).not.toThrow();
+        });
+    });
+});

--- a/test/utils/Utils.spec.js
+++ b/test/utils/Utils.spec.js
@@ -35,5 +35,33 @@ define([
                 });
 
             });
+
+            describe('splitOnMissingValues', function() {
+                it('splits an array on indices where a member has a null value in a property', function() {
+                    expect(Nugget.Utils.splitOnMissingValues([
+                        { x: 1,    y: 1 },
+                        { x: null, y: 2 },
+                        { x: 3,    y: 3 },
+                        { x: 4,    y: null },
+                        { x: 5,    y: null },
+                        { x: 6,    y: 6 },
+                        { x: 7,    y: 7 },
+                        { x: null, y: 8 }
+                    ], ['x', 'y'])).toEqual([
+                        [ { x: 1, y: 1 } ],
+                        [ { x: 3, y: 3 } ],
+                        [ { x: 6, y: 6 },
+                          { x: 7, y: 7 } ]
+                    ]);
+
+                    expect(Nugget.Utils.splitOnMissingValues([
+                        { x: 1 }, { x: 2 }, { x: 3 }
+                    ], ['x'])).toEqual([
+                        [ { x: 1 }, { x: 2 }, { x: 3 } ]
+                    ]);
+
+                    expect(Nugget.Utils.splitOnMissingValues([], ['x'])).toEqual([]);
+                });
+            });
         });
     });

--- a/test/views/ScatterGraph.spec.js
+++ b/test/views/ScatterGraph.spec.js
@@ -251,5 +251,53 @@ function (
             expect(circleDataChecker.calls.allArgs()).toEqual([[newData[0]], [newData[1]], [newData[2]]]);
             expect(errorBarDataChecker.calls.allArgs()).toEqual([[newData[0]], [newData[1]], [newData[2]]]);
         });
+
+        describe('sparse data series', function() {
+            beforeEach(function() {
+                chart.remove(scatterGraph);
+            });
+
+            it('should only draw points for data values with required keys', function() {
+                dataSeries = new Nugget.SparseNumericalDataSeries([
+                    { x_value: 0, y_value: 0 },
+                    { x_value: 1, y_value: 1 },
+                    { x_value: 2, y_value: null },
+                    { x_value: null, y_value: 3 },
+                    { x_value: 4, y_value: 4 },
+                    { x_value: 5, y_value: null },
+                    { x_value: 6, y_value: null },
+                    { x_value: 7, y_value: 0 },
+                    { x_value: 8, y_value: 0 },
+                    { x_value: 9, y_value: null }
+                ]);
+
+                scatterGraph = new Nugget.ScatterGraph({ dataSeries: dataSeries });
+                chart.add(scatterGraph);
+                chart.update();
+
+                expect($svg.find('circle.point').length).toEqual(5);
+            });
+
+            it('should only render error bars for data values with required', function() {
+                dataSeries = new Nugget.SparseNumericalDataSeries([
+                    { x_value: 0, y_value: 2, y_min: 1, y_max: 5 },
+                    { x_value: 1, y_value: null },
+                    { x_value: null, y_value: 2 },
+                    { x_value: 3, y_value: 3, y_min: null, y_max: 4 },
+                    { x_value: 4, y_value: 4, y_min: 2, y_max: 5 },
+                    { x_value: 5, y_value: 3, y_min: 1, y_max: null, },
+                    { x_value: 6, y_value: 4, y_min: 2 },
+                ]);
+
+                scatterGraph = new Nugget.ScatterGraph({
+                    dataSeries: dataSeries,
+                    showErrorBars: true
+                });
+                chart.add(scatterGraph);
+                chart.update();
+
+                expect($svg.find('.error_bar').length).toEqual(2);
+            });
+        });
     });
 });


### PR DESCRIPTION
When a line graph is given a data series that contains missing values, it should render multiple disconnected lines. Currently, missing values must be filtered out ahead of time, which results in a line connecting points on either side of the missing values.