### PR TITLE
Allow ScatterGraph points to have radius of zero

### DIFF
--- a/lib/views/ScatterGraph.js
+++ b/lib/views/ScatterGraph.js
@@ -5,7 +5,7 @@ class ScatterGraph extends Graph {
         super(options);
 
         var config = this.config.ScatterGraph;
-        this.radius = options.radius || config.radius;
+        this.radius = (options.radius != null) ? options.radius : config.radius;
         this.color = options.color;
         this.showErrorBars = options.showErrorBars;
         this.guideClassName = 'y_guide-' + this.id;


### PR DESCRIPTION
Sometimes you only want to show a line with error bars, but since error bars are part of the ScatterGraph the only way to do that is set the point radius to zero. 